### PR TITLE
don't use bold to format text, ref #18

### DIFF
--- a/conduct/index.html
+++ b/conduct/index.html
@@ -197,10 +197,10 @@ active: 'Conduct & Safety'
 
                     <h3>Lanyard color code</h3>
                     <ul>
-                        <li><b style="color: #036103">Solid green</b> printed with {code4lib}: Photographs always okay – this represents expressly-given permission beforehand</li>
+                        <li><span style="color: #036103;font-weight: 700;">Solid green</span> printed with {code4lib}: Photographs always okay – this represents expressly-given permission beforehand</li>
                         {% comment %} not very yellow because yellow's contrast is too low {% endcomment %}
-                        <li><b style="color: #88880d">Yellow</b>: Ask before photographing</li>
-                        <li><b style="color: #710d0d">Red</b>: Photographs never okay, don’t ask</li>
+                        <li><span style="color: #88880d;font-weight: 700;">Yellow</span>: Ask before photographing</li>
+                        <li><span style="color: #710d0d;font-weight: 700;">Red</span>: Photographs never okay, don’t ask</li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
for a11y audit