### PR TITLE
fix disappeared keynote proposals

### DIFF
--- a/_includes/homepage/pre_conference.html
+++ b/_includes/homepage/pre_conference.html
@@ -94,7 +94,7 @@
     {% endif %}
 
     <!-- Proposals -->
-    {% if site.data.conf.talk-proposals.show or site.data.conf.panel-porposals.show or site.data.conf.workshop-proposals.show or site.data.conf.shirt-proposals.show or site.data.conf.host-proposals.show %}
+    {% if site.data.conf.talk-proposals.show or site.data.conf.panel-porposals.show or site.data.conf.workshop-proposals.show or site.data.conf.shirt-proposals.show or site.data.conf.host-proposals.show or site.data.conf.keynote-proposals.show %}
     <div class="row">
         <div class="col-xs-12">
             <h4 class="expo">Proposals</h4>


### PR DESCRIPTION
in the very long set of conditions that determines if the "proposals" block shows:

```
{% if site.data.conf.talk-proposals.show or site.data.conf.panel-porposals.show or site.data.conf.workshop-proposals.show or site.data.conf.shirt-proposals.show or site.data.conf.host-proposals.show %}
```

we had omitted `site.data.conf.keynote-proposals.show`

btw there has to be a more elegant way to code this than a huge or..or..or list