### PR TITLE
Add Preconference Workshops

### DIFF
--- a/_data/locations.yml
+++ b/_data/locations.yml
@@ -1,0 +1,4 @@
+- id: doubletree
+  name: 'San José DoubleTree by Hilton'
+  google_maps: 'https://goo.gl/maps/BxYz1JA4KgQ2'
+  embed_code: 'https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3170.7635193017622!2d-121.92490158469384!3d37.371772079834926!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x808fcbea46de432b%3A0x143d6b946b2164f5!2sDoubleTree+by+Hilton+Hotel+San+Jose!5e0!3m2!1sen!2sus!4v1541711983965'

--- a/_data/locations.yml
+++ b/_data/locations.yml
@@ -2,3 +2,33 @@
   name: 'San José DoubleTree by Hilton'
   google_maps: 'https://goo.gl/maps/BxYz1JA4KgQ2'
   embed_code: 'https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3170.7635193017622!2d-121.92490158469384!3d37.371772079834926!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x808fcbea46de432b%3A0x143d6b946b2164f5!2sDoubleTree+by+Hilton+Hotel+San+Jose!5e0!3m2!1sen!2sus!4v1541711983965'
+  floor_plan: https://doubletree3.hilton.com/resources/media/dt/JOSE-DT/en_US/pdf/JOSE.Floorplans.May04.pdf
+  rooms:
+    - id: tbd
+      name: 'To Be Determined'
+    - id: san-martin
+      name: 'San Martin'
+    - id: san-juan
+      name: 'San Juan'
+    - id: san-carlos
+      name: 'San Carlos'
+    - id: san-jose
+      name: 'San Jose'
+    - id: santa-clara
+      name: 'Santa Clara'
+    - id: carmel
+      name: 'Carmel'
+    - id: monterey
+      name: 'Monterey'
+    - id: pine
+      name: 'Pine'
+    - id: fir
+      name: 'Fir'
+    - id: oak
+      name: 'Oak'
+    - id: sierra
+      name: 'Sierra'
+    - id: cascade
+      name: 'Cascade'
+    - id: donner
+      name: 'Donner'

--- a/_includes/workshops/card.html
+++ b/_includes/workshops/card.html
@@ -1,5 +1,5 @@
 {% assign workshop = include.workshop %}
-{% capture post_length %}{% if workshop.time == 'am' %}9:30-12:30{% elsif workshop.time == 'pm' %}2:30-5:30{% else %}9:00-5:00 (w/ lunch break){% endif %}{% endcapture %}
+{% capture post_length %}{% if workshop.time == 'am' %}9:00-12:00{% elsif workshop.time == 'pm' %}2:00-5:00{% else %}9:00-5:00 (w/ lunch break){% endif %}{% endcapture %}
 {% assign location = site.data.locations | where: 'id', workshop.location | first %}
 {% assign location_display = location.name %}
 {% if workshop.room %}

--- a/_layouts/presentation.html
+++ b/_layouts/presentation.html
@@ -3,7 +3,7 @@
 
 {% if page.type == 'workshop' %}
     {% assign page_date = page.date %}
-    {% capture page_length %}{% if page.time == 'am' %}9:30-12:30{% elsif page.time == 'pm' %}2:30-5:30{% else %}9:00-5:00 (w/ lunch break){% endif %}{% endcapture %}
+    {% capture page_length %}{% if page.time == 'am' %}9:00-12:00{% elsif page.time == 'pm' %}2:00-5:00{% else %}9:00-5:00 (w/ lunch break){% endif %}{% endcapture %}
     {% assign location = site.data.locations | where: 'id', page.location | first %}
     {% assign location_display = location.name %}
     {% if workshop.room %}
@@ -23,7 +23,7 @@
             <h1>{{ page.title }}{% if page.full == true %}<small class="text-danger">This workshop is full</small>{% endif %}</h1>
 
             {{ content }}
-            
+
             {% if page.youtube_key %}
             <iframe width="560" height="315" src="https://www.youtube.com/embed/{{ page.youtube_key }}" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
             {% endif %}

--- a/_posts/2019-02-19-Accessible-Websites-Made-Easy-How-To-Assess-Issues-and-Create-Better-Experiences.html
+++ b/_posts/2019-02-19-Accessible-Websites-Made-Easy-How-To-Assess-Issues-and-Create-Better-Experiences.html
@@ -1,0 +1,18 @@
+---
+layout: presentation
+type: workshop
+categories: workshops
+speakers-text: Michaela Blackham
+speakers:
+  - michaela-blackham
+time: am
+startTime: 9:00
+endTime: 12:00
+location: doubletree
+#room: carmel
+slugTitle: accessible-websites-made-easy-how-to-assess-issues-and-create-better-experiences
+title: Accessible Websites Made Easy&#58; How To Assess Issues and Create Better Experiences
+---
+<p>You need to make your website ADA compliant, whether it is WCAG or 508, but what does that actually mean? We’ll go over the basics of accessibility and how it relates to you, your users, and your website. We’ll dive into best practices for testing, recommended automated tools to use and demo a site with a screen reader to better understand your user experience. Attendees will audit their site for accessibility guidelines and then together, we will cover the standards for fixing and avoiding common issues. Attendees should bring a laptop. Some extensions may be recommended to download.
+
+NOTE: The screen reader portion of this demo will be using Mac's proprietary screen reader "Voiceover (VO)" which will vary slightly from other assistive technologies like NVDA and Jaws.</p>

--- a/_posts/2019-02-19-Advocating-for-Library-Accessibility-An-Introduction.html
+++ b/_posts/2019-02-19-Advocating-for-Library-Accessibility-An-Introduction.html
@@ -1,0 +1,22 @@
+---
+layout: presentation
+type: workshop
+categories: workshops
+speakers-text: Katherine Deibel, Jenn Dandle
+speakers:
+  - katherine-deibel
+  - jenn-dandle
+time: am
+startTime: 9:00
+endTime: 12:00
+location: doubletree
+#room: fir
+slugTitle: advocating-for-library-accessibility-an-introduction
+title: Advocating for Library Accessibility&#58; An Introduction
+---
+<p>Libraries must ensure that users of all abilities can successfully use the technologies we provide. Despite the many ethical and legal motivations, not all of our technologies meet accessibility standards. Ultimately, the responsibility for making technologies accessible falls to the developers and vendors, but it does not begin with them. Advocacy from library staff of all duties is crucial for ensuring that disability access is a priority in library technology.
+
+This workshop provides a foundation of skills and knowledge for becoming an accessibility advocate for any library worker. Background on disability types, assistive technologies, standards, and laws will be provided. Basic technology accessibility concepts will be covered, including simple tests and questions for working with vendors. Depending on the interests and background of workshop attendees, additional topics may be explored such as document formats, metadata, or testing practices.
+
+No technical expertise is required of participants, although some discussions will get into HTML and other semantic markup languages. Attendees should bring a laptop or similar device that will enable them to participate in activities. Some software installations may be required.
+</p>

--- a/_posts/2019-02-19-All-the-Things-NiFi-for-Data-Processing-API-requests-and-More.html
+++ b/_posts/2019-02-19-All-the-Things-NiFi-for-Data-Processing-API-requests-and-More.html
@@ -1,0 +1,16 @@
+---
+layout: presentation
+type: workshop
+categories: workshops
+speakers-text: Lauren Ajamie
+speakers:
+  - lauren-ajamie
+time: full
+startTime: 9:00
+endTime: 17:00
+location: doubletree
+#room: san-martin
+slugTitle: all-the-things-nifi-for-data-processing-api-requests-and-more-
+title: All the Things! NiFi for Data Processing, API requests and More!
+---
+<p>The Hesburgh Libraries have been using NiFi, an Apache data routing, processing and transformation tool, for a increasing number of applications including patron loading, Git pipelines and student billing. This session will include an introduction to NiFi and demo of a few of our NiFi-based services, followed by a hands-on workshop where participants will build their own flows.</p>

--- a/_posts/2019-02-19-ArchivesSpace-in-a-Day-Installing-and-Customizing-AS-in-the-Cloud.html
+++ b/_posts/2019-02-19-ArchivesSpace-in-a-Day-Installing-and-Customizing-AS-in-the-Cloud.html
@@ -1,0 +1,19 @@
+---
+layout: presentation
+type: workshop
+categories: workshops
+speakers-text: Tristan Dahn
+speakers:
+  - tristan-dahn
+time: full
+startTime: 9:00
+endTime: 17:00
+location: doubletree
+#room: san-carlos
+slugTitle: archivesspace-in-a-day-installing-and-customizing-as-in-the-cloud
+title: ArchivesSpace in a Day&#58; Installing and Customizing AS in the Cloud
+---
+<p>Are you part of a small library or a lone arranger? Does your archives need an online portal to your finding aids? ArchivesSpace (AS) is rapidly becoming the standard application in the field but setting up an instance can be intimidating for small institutions. Intended for beginning AS users, this session will cover creating a cloud-based server, installing and running AS, customizing the theme and settings, and finally creating a reverse proxy for displaying the front end application online with a clean URL.
+
+Participants will learn: Setting up a Linux based cloud server on AWS, including security settings and permissions. Downloading and installing AS with a quick overview of the staff and public interface. Configuring and creating a theme for AS using simple plugins. Setting up a reverse proxy to direct web traffic to your AS instance with a clean URL. Other topics such as upgrading AS and installing an SSL certificate might be covered, time permitting. Participants will need a personal computer with a working SSH client and a basic understanding of command line tools.
+</p>

--- a/_posts/2019-02-19-Automated-testing-with-Selenium-IDE-no-programming-required.html
+++ b/_posts/2019-02-19-Automated-testing-with-Selenium-IDE-no-programming-required.html
@@ -1,0 +1,21 @@
+---
+layout: presentation
+type: workshop
+categories: workshops
+speakers-text: Kaitlin Newson
+speakers:
+  - kaitlin-newson
+time: pm
+startTime: 2:00 PM
+endTime: 5:00 PM
+location: doubletree
+#room: santa-clara
+slugTitle: automated-testing-with-selenium-ide-no-programming-required
+title: Automated testing with Selenium IDE, no programming required
+---
+
+<p>Automated testing is a key part of ensuring that the software we develop and provide works effectively and functionally. For the software used by patrons, automated testing can point us to the bugs we need to fix, or the issues that we need to report to software maintainers, before they cause problems for our users. In this hands-on workshop, we’ll start by discussing what automated testing is, different kinds of testing, and provide an overview of some commonly used tools and methods. Then, we’ll dive into how to scope and create automated tests using Katalon Recorder [1], a browser plugin for testing web-based software. Participants will work through several exercises, and will come away with an understanding of how to make their own automated tests without requiring programming knowledge.
+
+<p>This workshop is beginner-friendly; no prior programming knowledge is required, but attendees will need to bring a laptop.
+
+<p>1. https://www.katalon.com/resources-center/blog/katalon-automation-recorder/

--- a/_posts/2019-02-19-Fail4Lib-2019.html
+++ b/_posts/2019-02-19-Fail4Lib-2019.html
@@ -1,0 +1,16 @@
+---
+layout: presentation
+type: workshop
+categories: workshops
+speakers-text: Andreas Orphanides
+speakers:
+  - andreas-orphanides
+time: am
+startTime: 9:00
+endTime: 12:00
+location: doubletree
+#room: monterey
+slugTitle: fail4lib-2019
+title: Fail4Lib 2019
+---
+<p>Failure is the "f" word: the dreaded taboo that every developer, project manager, and organizational leader fears. Our natural inclination is to flee failure, and, when we can't avoid it, to bury it away. But failure has intrinsic value and is an essential step on the path to professional and organizational success. And since it's inevitable, we ought to learn how to face failure, how to talk about it as professionals, and how to grow from it. Fail4Lib, now in its 7th year, is the perennial Code4Lib preconference dedicated to discussing and coming to terms with the failures that we all encounter in our professional lives. It is a safe space for us to explore failure, to talk about our own experiences with failure, and to encourage enlightened risk taking. The goal of Fail4Lib is for participants -- and their organizations -- to get better at failing gracefully, so that when we do fail, we do so in a way that moves us forward. This half-day preconference will consist of case studies, round-table discussions, and, for those interested in sharing, lightning talks on failures we've dealt with in our own work. Both newcomers and Fail4Lib veterans are welcome.</p>

--- a/_posts/2019-02-19-Forensic-Files-Episode-1-Fishing-for-the-Truth.html
+++ b/_posts/2019-02-19-Forensic-Files-Episode-1-Fishing-for-the-Truth.html
@@ -1,0 +1,22 @@
+---
+layout: presentation
+type: workshop
+categories: workshops
+speakers-text: Sara Allain
+speakers:
+  - sara-allain
+time: am
+startTime: 9:00 AM
+endTime: 12:00 PM
+location: doubletree
+#room: cascade
+slugTitle: forensic-files-episode-1-fishing-for-the-truth-
+title: Forensic Files, Episode 1&#58; "Fishing for the Truth"
+---
+<p>This workshop is complementary with Forensic Files, Episode 2: "A Purr-fect Match" but attendance in the second workshop is not required.
+
+What even are files - and what’s a format? What about video, which is several formats making up one file? And what about disk images, with many files inside? And what about Google Docs, which aren’t even files at all?!
+
+In this session, we will look at what makes up a file, how formats are defined, and how to analyze files for digital preservation. We’ll take a look at format registries like PRONOM and the Library of Congress Format Descriptions, check out some file analysis tools like Siegfried, JHOVE, and MediaInfo, and - as a hands-on exercise - use a hex editor to look at files and make sense of them.
+
+We are committed to making this a low-barrier session for those who are interested in learning more about file formats. No technical expertise is required of participants, although we will be discussing file formats in detail. Attendees should bring a laptop or similar device that will enable them to participate in activities.</p>

--- a/_posts/2019-02-19-Forensic-Files-Episode-2-A-Purr-fect-Match.html
+++ b/_posts/2019-02-19-Forensic-Files-Episode-2-A-Purr-fect-Match.html
@@ -1,0 +1,21 @@
+---
+layout: presentation
+type: workshop
+categories: workshops
+speakers-text: Sara Allain
+speakers:
+  - sara-allain
+  - ashley-blewer
+time: pm
+startTime: 2:00 PM
+endTime: 5:00 PM
+location: doubletree
+#room: cascade
+slugTitle: forensic-files-episode-2-a-purr-fect-match
+title: Forensic Files, Episode 2&#58; "A Purr-fect Match"
+---
+<p>This workshop is complementary with Forensic Files, Episode 1: “Fishing for the Truth” but attendance in the first workshop is not required.
+
+<p>This workshop will go through the steps necessary to preserve and grant access to digital cultural objects, and the decision-making process involved when working with files. We will follow objects through their life cycles, stopping to interrogate crucial preservation steps along the way, such as digitization, characterization, metadata extraction,  normalization, derivative generation, and presentation. We will discuss which tools are appropriate for each of the tasks, and what are the pitfalls to using these tools. We will also talk about resources that are available to help you determine the “just-right” level of preservation actions for your situation.
+
+<p>We are committed to making this a low-barrier session for those who are interested in learning more about preservation planning. No technical expertise is required of participants, although we will be discussing file formats and preservation tasks in detail.

--- a/_posts/2019-02-19-ISLE-Islandora-for-All.html
+++ b/_posts/2019-02-19-ISLE-Islandora-for-All.html
@@ -1,0 +1,22 @@
+---
+layout: presentation
+type: workshop
+categories: workshops
+speakers-text: David Keiser-Clark, Derek Merleaux, Ben Rosner
+speakers:
+  - david-keiser-clark
+  - derek-merleaux
+  - ben-rosner
+time: am
+startTime: 9:00
+endTime: 12:00
+location: doubletree
+#room: oak
+slugTitle: isle-islandora-for-all
+title: ISLE&#58; Islandora for All
+---
+<p>This is a friendly but comprehensive introduction to ISLE (bit.ly/ISLE-INFO). We will provide an overview, a public demonstration, and guide you in creating a local development environment of the entire Islandora stack on your laptop (or to share with a new friend): this process is remarkably similar to creating a full production Islandora stack on an institutional server or within cloud services. We’ll provide basic instructions on how to interact with your Islandora repository, including how to ingest, edit and delete a sample set of digital objects. We’ll show you how easy it is to use ISLE to maintain (update) your Islandora stack, and then how to run automated tests to verify success. We’ll share an overview of how you can create permanent customizations to your site that will persist through ISLE updates. We will provide a list of what’s needed to migrate to ISLE from a pre-existing Islandora installation, and from another digital repository platform. And we’ll make time for questions and discuss the future roadmap of ISLE and Islandora.
+
+ISLE uses replaceable Docker images to streamline and largely automate the process of installing and maintaining the entire Islandora 7.x stack, while at the same time enabling institutions to create customizations that persist separately from core code. The result is the ability to easily, quickly and regularly update an institution’s entire Islandora stack. Maintaining ISLE requires significantly less time and staff, and also reduces the dependency on expert technical staff and outside vendors.
+
+Everyone will succeed in this workshop! We’ve designed it especially for people who own, manage or work closely with their repository, including a full range of breadth that includes metadata specialists, archivists, developers, systems administrators, directors and CIOs.</p>

--- a/_posts/2019-02-19-Introduction-to-Handling-Data-and-SQL.html
+++ b/_posts/2019-02-19-Introduction-to-Handling-Data-and-SQL.html
@@ -1,0 +1,16 @@
+---
+layout: presentation
+type: workshop
+categories: workshops
+speakers-text: Jordan Pedersen
+speakers:
+  - jordan-pedersen
+time: full
+startTime: 9:00
+endTime: 17:00
+location: doubletree
+#room: pine
+slugTitle: introduction-to-handling-data-and-sql
+title: Introduction to Handling Data and SQL
+---
+<p>Drawing from the Library Carpentries lessons Data intro for librarians, Tidy data for librarians and SQL for librarians, this session will introduce learners to the basics of handling data, along with how to query their using regular expressions and SQL (Standard Query Language). It will also introduce users to a free tool (SQLite), resources to learn advanced querying techniques, and where to seek guidance if they encounter problems with their own real-world applications after the session.</p>

--- a/_posts/2019-02-19-LD4Ps-Sinopia-Linked-Data-Editing-Environment.html
+++ b/_posts/2019-02-19-LD4Ps-Sinopia-Linked-Data-Editing-Environment.html
@@ -1,0 +1,35 @@
+---
+layout: presentation
+type: workshop
+categories: workshops
+speakers-text: Jeremy Nelson, Astrid Usong, Huda Khan
+speakers:
+  - jeremy-nelson
+  - astrid-usong
+  - huda-khan
+time: full
+startTime: 9:00
+endTime: 17:00
+location: doubletree
+#room: donner
+slugTitle: ld4p-s-sinopia-linked-data-editing-environment
+title: LD4P's Sinopia Linked Data Editing Environment
+---
+<p>The Sinopia Linked Data Editing Environment is part of a Mellon Grant funded
+the Linked Data for Production 2 (LD4P2) project. Based on the
+Library of Congress's BIBFRAME Editor (BFE) and BIBFRAME Profile Editor
+projects, Sinopia is a linked data platform for original and cooperative
+cataloging using BIBFRAME and other vocabularies.
+
+Running on Amazon Web Services, the technical implementation of Sinopia is a
+project of Stanford University Libraries that in cooperation of a Cornell
+University-lead project, Questioning Authority search server, is scheduled to release an minimal viable product (MVP) in April 2019. A Cohort of over
+17 universities and colleges are also developing linked-data technologies, practices, and workflows using Sinopia.
+
+This two session workshop will cover the following topics:
+
+*  The Sinopia Platform design and development process covering the technologies, use cases, work cycles for this MVP and a retrospective of what the team has learned so far in the process.
+
+*  How Community Profiles are being created, shared, and how the profiles are used in the Sinopia Editor in the Cohorts projects. We will also demonstrate how the workshops participants can create and reuse their own metadata profiles in Sinopia.
+
+*  Participation in the requirements process for the second Sinopia work cycle. This will include "blue sky" imagining of what the linked data creation environment could become including but not limited to; metadata visualizations, advanced user interfaces, machine learning, and any other topics of interest.</p>

--- a/_posts/2019-02-19-Leveling-Up-Your-Accessibility-Skills-The-ARIA-Feat.html
+++ b/_posts/2019-02-19-Leveling-Up-Your-Accessibility-Skills-The-ARIA-Feat.html
@@ -1,0 +1,20 @@
+---
+layout: presentation
+type: workshop
+categories: workshops
+speakers-text: Katherine Deibel
+speakers:
+  - katherine-deibel
+time: pm
+startTime: 2:00 PM
+endTime: 5:00 PM
+location: doubletree
+#room: fir
+slugTitle: leveling-up-your-accessibility-skills-the-aria-feat
+title: Leveling Up Your Accessibility Skills&#58; The ARIA Feat
+---
+<p>Are you a web developer or do you create web content? Do you use JavaScript to make dynamic user interfaces? If you answered yes, then you should concern yourself with making those dynamic elements accessible and usable to as many as possible. One of the most powerful tools currently available for making webpages accessible is ARIA, the Accessible Rich Internet Applications specification. However, as Spider-Man has taught us, with great power comes great responsibility. The first rule of ARIA is that no ARIA is always superior to bad ARIA.
+
+This workshop will teach you the basics for responsibly leveraging the full power of ARIA to make great accessible web pages. Through several hands-on exercises, participants will come to understand the purpose and power of ARIA and how to apply it to a variety of different dynamic web elements. Topics will include semantic HTML, ARIA landmarks and roles, expanding/collapsing content and modal dialog. Participants will also be taught some basic use of the screen reader NVDA for use in accessibility testing. Most importantly, the workshop will provide you with tools and materials so that you can keep on learning as HTML, JavaScript and ARIA continue to evolve and expand.
+
+This is a hands-on workshop with web programming exercises. Attendees should have familiarity with  basic HTML, CSS, and JavaScript. Attendees should also bring a laptop or tablet and be ready to download exercises from online or via a provided USB drive.</p>

--- a/_posts/2019-02-19-Leveraging-Serverless-Technologies-to-Improve-Library-Workflows.html
+++ b/_posts/2019-02-19-Leveraging-Serverless-Technologies-to-Improve-Library-Workflows.html
@@ -1,0 +1,27 @@
+---
+layout: presentation
+type: workshop
+categories: workshops
+speakers-text: Karen Coombs
+speakers:
+  - karen-coombs
+time: am
+startTime: 9:00
+endTime: 12:00
+location: doubletree
+#room: sierra
+slugTitle: leveraging-serverless-technologies-to-improve-library-workflows
+title: Leveraging Serverless Technologies to Improve Library Workflows
+---
+<p>Serverless computing: it may sound too good to be true, but it isn’t! Serverless is an emerging cloud-computing execution model in which server management issues are hidden from the developer. When deployed properly, this model allows you to focus on writing code, while your cloud provider takes care of “all that devops stuff.”
+
+
+This workshop will provide an overview of the concepts of serverless, the major providers in the serverless space, related technologies, relevant languages and frameworks. Participants will discuss use cases where utilizing these technologies can improve library workflows, reduce costs and facilitate innovation. Workshop participants will work with several types of serverless code examples including:
+
+    Serverless web application
+
+    Scheduled and/or event triggered data sync
+
+    AWS Lambda function to support Alexa skill
+
+    AWS Lambda to send alerts </p>

--- a/_posts/2019-02-19-Library-apps-and-the-modern-dev-workflow.html
+++ b/_posts/2019-02-19-Library-apps-and-the-modern-dev-workflow.html
@@ -1,0 +1,16 @@
+---
+layout: presentation
+type: workshop
+categories: workshops
+speakers-text: Josh Weisman
+speakers:
+  - josh-weisman
+time: pm
+startTime: 2:00 PM
+endTime: 5:00 PM
+location: doubletree
+#room: san-juan
+slugTitle: library-apps-and-the-modern-dev-workflow
+title: Library apps and the modern dev workflow
+---
+<p>Dev-ops, continuous deployment, serverless, cloud, API mocking, SPAs- terms which didn’t exist just a few years ago and are now firmly entrenched in the modern development workflow. These concepts can be overwhelming to all but the most experienced developers. In this session, we’ll build a library application taking advantage of such tools as OpenAPI, Swagger and Heroku and try to demystify some concepts along the way.</p>

--- a/_posts/2019-02-19-Maximizing-library-inventories.html
+++ b/_posts/2019-02-19-Maximizing-library-inventories.html
@@ -1,0 +1,16 @@
+---
+layout: presentation
+type: workshop
+categories: workshops
+speakers-text: Craig Boman
+speakers:
+  - craig-boman
+time: pm
+startTime: 2:00 PM
+endTime: 5:00 PM
+location: doubletree
+#room: carmel
+slugTitle: maximizing-library-inventories
+title: Maximizing library inventories
+---
+<p>Although a decreasing part of our overall library budgets, print books continue to provide immense value to our patrons, occupying much of our spaces. Despite advances in inventory technology many libraries may still be using legacy inventory systems to help compare what should be on the shelf with what is on the shelf, in the right order. During this workshop we will explore how to maximize your use of open source technology during the course of a print inventory in Google sheets.</p>

--- a/_posts/2019-02-19-Practicing-ethics-in-information-professions.html
+++ b/_posts/2019-02-19-Practicing-ethics-in-information-professions.html
@@ -1,0 +1,22 @@
+---
+layout: presentation
+type: workshop
+categories: workshops
+speakers-text: Sarah Rice, Bernadette Irizarry
+speakers:
+  - sarah-rice
+  - bernadette-irizarry
+time: am
+startTime: 9:00
+endTime: 12:00
+location: doubletree
+#room: san-juan
+slugTitle: practicing-ethics-in-information-professions
+title: Practicing ethics in information professions
+---
+<p>People who organize information for discovery and use not only make information accessible but also provide the lens through which others experience it. Designing information spaces involves making and imposing value choices, which positions us firmly in the realm of ethics. This topic is especially relevant as we hear more about “fake news,” “biased algorithms,” and unethical uses of personal data.
+
+Individually, we have considered ethics at the micro level, for instance by finding ways to do good in specific projects or situations. But to what extent have we thought about ethics in the context of our overall profession? When we design do we, as practitioners, surrender our moral authority to someone else? Or do we follow a professional code?
+
+This workshop will present key questions and guidelines for considering and discussing a code of ethics that can be applied widely within information professions. We will also enact real-world scenarios and develop a story to use in talking with other professionals (teammates, colleagues, managers, etc.) about key ethical considerations in our work.
+</p>

--- a/_posts/2019-02-19-Protecting-Patron-Privacy-Pythonically.html
+++ b/_posts/2019-02-19-Protecting-Patron-Privacy-Pythonically.html
@@ -1,0 +1,23 @@
+---
+layout: presentation
+type: workshop
+categories: workshops
+speakers-text: Drew Heles
+speakers:
+  - drew-heles
+time: pm
+startTime: 2:00 PM
+endTime: 5:00 PM
+location: doubletree
+#room: sierra
+slugTitle: protecting-patron-privacy-pythonically
+title: Protecting Patron Privacy Pythonically
+---
+<p>Do you handle patron data?
+Would you like to, but the fear of compromising your patrons' privacy provokes paralysis?
+Do you handle it all the time and wonder what’s the BFD about privacy anyway, it’s just a book checkout, rite?
+Would you like to have confidence that you are managing your patron data responsibly, so that you can do something useful with it?
+
+If you answered “yes” to any of these questions, this workshop is for you. In it, we will discuss and implement strategies for de-identifying and anonymizing personally identifiable information (PII) within patron data. We will do this by simulating the Transform step of an Extract, Transform, Load (ETL) workflow. We will use the python programming language, due to its easy setup, gentle learning curve, availability of useful libraries for this purpose, and popularity for ETL applications. However, the concepts and techniques covered could be ported to other environments and/or languages as needed. While experienced programmers are welcome, this workshop is intended to be useful to you even if you have minimal programming experience.
+
+This will be a hands-on workshop, so you should bring a laptop upon which you have installed or can install the relevant software. Instructions will be provided in advance of the workshop and support will be available on the day in case you need it. In order to get the most out of the material, you should be comfortable with programmatic thinking. Familiarity with fundamental programming concepts (variable assignment, looping, etc) would also be helpful. If you’re not sure if this is the right workshop for you, we’d be happy to talk before you register.</p>

--- a/_posts/2019-02-19-Representing-diversity-on-the-web-How-to-create-inclusive-virtual-campus-environments.html
+++ b/_posts/2019-02-19-Representing-diversity-on-the-web-How-to-create-inclusive-virtual-campus-environments.html
@@ -1,0 +1,22 @@
+---
+layout: presentation
+type: workshop
+categories: workshops
+speakers-text: Conny Liegl
+speakers:
+  - conny-liegl
+time: pm
+startTime: 2:00 PM
+endTime: 5:00 PM
+location: doubletree
+#room: oak
+slugTitle: representing-diversity-on-the-web-how-to-create-inclusive-virtual-campus-environments
+title: Representing diversity on the web&#58; How to create inclusive virtual campus environments
+---
+<p>Diversity and inclusivity is the focus of many of our academic institutions’ mission statements - but does your website reflect these standards?
+Often unconscious, wrong decisions on copy and multimedia content can create an unwelcoming virtual environment to underrepresented groups. This might cause prospective students or faculty/staff to choose a different school/employer, or discourage current students and employees from seeking support and finding diversity resources and content on the web. Additionally, if your content is not accessible, you are excluding a wide variety of users.
+
+My workshop will help to identify and avoid common pitfalls and educate attendees on solutions for improving your institute’s online presence.
+We’ll be looking at various nation-wide examples from around the web and social media and learn to create accessible, inclusive digital content.
+
+</p>

--- a/_posts/2019-02-19-Solr-for-newbies.html
+++ b/_posts/2019-02-19-Solr-for-newbies.html
@@ -1,0 +1,33 @@
+---
+layout: presentation
+type: workshop
+categories: workshops
+speakers-text: Hector Correa
+speakers:
+  - hector-correa
+time: pm
+startTime: 2:00 PM
+endTime: 5:00 PM
+location: doubletree
+#room: tbd
+slugTitle: solr-for-newbies
+title: Solr for newbies
+---
+<p>This is an introductory workshop to Solr, the fast and open source search platform that powers a lot of library products. This workshop is geared to anyone that has never used Solr, or uses it but has not explored some of the features that Solr offers out of the box, or looked under the hood to see how it can be configured.
+
+We'll start the workshop with a quick review on how Solr stores data and the process that it goes through when a search is submitted.
+
+We'll then go through a tour of the main features in Solr:
+
+* Indexing your data: where all of it starts
+* Solr's document-based data model and what that means to you
+* How to configure fields for different needs (ever wonder what the "_t" means in a Solr field and how it's different from a "_s" field?)
+* What are Search Request Handlers and Query parsers (ever been puzzled by dismax vs edismax?)
+* What's the difference between the "q" and "fq" parameters when you search
+* How to debug queries and figure out why the resulting documents are being picked (or not)
+* How to tweak the ranking of results
+* How to use facets, synonyms, and hit highlighting
+* How to configure search term suggestions
+* How to configure replication (it's easy) and how you can use it
+
+While practical, this workshop does not require you to be a coder. The idea is for you to learn the concepts, features, and how they work. If you choose, we'll show you how to install Solr on your machine to experiment with the concepts as we go. But if you prefer not to install Solr (or updating configuration files is not your thing) you can still follow along and learn with us.</p>

--- a/_posts/2019-02-19-Using-Node-to-Listen-to-Alma-Webhooks.html
+++ b/_posts/2019-02-19-Using-Node-to-Listen-to-Alma-Webhooks.html
@@ -1,0 +1,16 @@
+---
+layout: presentation
+type: workshop
+categories: workshops
+speakers-text: Eli Zoller
+speakers:
+  - eli-zoller
+time: am
+startTime: 9:00
+endTime: 12:00
+location: doubletree
+#room: santa-clara
+slugTitle: using-node-to-listen-to-alma-webhooks
+title: Using Node to Listen to Alma Webhooks
+---
+<p>Heard about the Alma Webhooks? They may help you build robust functionality outside of Alma to enhance existing functionality or provide features which are not built in to Alma. Alma has webhooks for jobs ending, notifications, requests, users, loans, and bib and item updates. Participants will learn the basics of setting up and running a Node app, writing a listener for a webhook, and we'll build some functionality triggered by webhook actions.</p>

--- a/_posts/2019-02-19-Wait-what-Getting-your-bearings-with-ServerSpec.html
+++ b/_posts/2019-02-19-Wait-what-Getting-your-bearings-with-ServerSpec.html
@@ -1,0 +1,16 @@
+---
+layout: presentation
+type: workshop
+categories: workshops
+speakers-text: Hardy Pottinger
+speakers:
+  - hardy-pottinger
+time: am
+startTime: 9:00
+endTime: 12:00
+location: doubletree
+#room: san-jose
+slugTitle: wait-what-getting-your-bearings-with-serverspec
+title: Wait, what? Getting your bearings with ServerSpec
+---
+<p>Library developers change jobs, we're always the newbie. ServerSpec is a fantastic tool for keeping track of exactly what is supposed to be running on which server. Chances are such tests don't exist in your current workplace; chances are such tests would be significantly helpful to your coworkers. This is a tool that should be in your box.</p>

--- a/_posts/2019-02-19-When-in-Rome-Bringing-Silicon-Valley-Startup-Methods-to-Library-Innovation.html
+++ b/_posts/2019-02-19-When-in-Rome-Bringing-Silicon-Valley-Startup-Methods-to-Library-Innovation.html
@@ -1,0 +1,18 @@
+---
+layout: presentation
+type: workshop
+categories: workshops
+speakers-text: Ellie Collier, Madeline Dale, Eric Frierson
+speakers:
+  - ellie-collier
+  - madeline-dale
+  - eric-frierson
+time: pm
+startTime: 2:00 PM
+endTime: 5:00 PM
+location: doubletree
+#room: monterey
+slugTitle: when-in-rome-bringing-silicon-valley-startup-methods-to-library-innovation
+title: When in Rome&#58; Bringing Silicon Valley Startup Methods to Library Innovation
+---
+<p>You've got an idea that you think might solve a problem for your users, but so much is standing in your way.  You don't have the time (nor permission!) to derail your day job on a concept that might not even pan out.  In this session, attendees will learn how to apply Eric Reis' Lean Startup concepts to projects in order to vet new ideas quickly, cheaply, and with scientific rigor - the way many successful startups in Silicon Valley do.  Quickly develop the seeds of a good idea into something that is undeniably great or learn lessons for the future by failing fast and risking little.  This workshop will apply the methods of the Startup Way to real problems, starting with the forming of an idea to having real data that points the way forward.  NOTE: While the presenters are from EBSCO, the content and opinions in the workshop are our own and will not include mention of any EBSCO products, we solemnly swear.</p>

--- a/_posts/2019-02-19-Working-on-Workshops-A-Little-Pedagogy-Goes-a-Long-Way.html
+++ b/_posts/2019-02-19-Working-on-Workshops-A-Little-Pedagogy-Goes-a-Long-Way.html
@@ -1,0 +1,21 @@
+---
+layout: presentation
+type: workshop
+categories: workshops
+speakers-text: Colin Nickels
+speakers:
+  - colin-nickels
+time: pm
+startTime: 2:00 PM
+endTime: 5:00 PM
+location: doubletree
+#room: san-jose
+slugTitle: working-on-workshops-a-little-pedagogy-goes-a-long-way
+title: Working on Workshops&#58; A Little Pedagogy Goes a Long Way
+---
+<p>The NCSU libraries led 327 workshops last year. Our workshops cover a wide array of topics including: Arduino, R, digital media, citation management, and systematic reviews. Developing these workshops takes time and effort. Through our experience, we have adopted strategies that demystify workshop design.
+
+In this workshop, we will share best practices, lessons learned the hard way, and a framework for workshop development. Bring your idea or existing workshop materials to overhaul; leave with a finished outline for a new workshop, access to NCSU Libraries workshop materials, and a set of helpful steps to go through when designing a new workshop.
+
+Participants will learn how to design a workshop using backward design: starting with learning outcomes, moving through assessment, intro activities and outlines.
+</p>

--- a/workshops/index.html
+++ b/workshops/index.html
@@ -11,7 +11,7 @@ title: Preconference Workshops
     </div>
     <div class="row">
         <div class="col-xs-12 col-sm-12">
-            <!-- <p>Half-day Workshops will start at 9:30 a.m. and 2:30 p.m. while full-day ones run 9:00 a.m. to 5:30 p.m..</p> -->
+            <p>Half-day Workshops will start at 9:00 a.m. and 2:00 p.m. while full-day ones run 9:00 a.m. to 5:00 p.m..</p>
         </div>
     </div>
     <div class="row" id="workshop-sorting-div">


### PR DESCRIPTION
- create locations.yml with just one location (everything's at the hotel this year)
- small start/end time edit to _layouts/presentation.html
- create 23 preconference workshop posts
- comment out the `room` frontmatter right now as it's unofficial—we won't need it until the conference

Please test the `/workshops/` path to make sure it works. There should be 9 morning sessions, 10 afternoon, and 4 full day. There's only one location so the location filter does nothing.

Things that are incomplete after this PR:

- while speaker IDs are included we don't have real data in speakers.yml yet, preconference promised to get us data by Monday
- I don't like that the workshop post `{{content}}` isn't processed as markdown…URLs aren't linked, going to open a separate bug for this