### PR TITLE
fix logic for the speakers section

### DIFF
--- a/_layouts/presentation.html
+++ b/_layouts/presentation.html
@@ -28,22 +28,34 @@
             <iframe width="560" height="315" src="https://www.youtube.com/embed/{{ page.youtube_key }}" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
             {% endif %}
 
+            <!-- determine if we should show the speakers block -->
+            {% assign show_speakers = false %}
             {% for speaker_id in page.speakers %}
-                {% assign speaker = site.data.speakers | where: 'id', speaker_id | first %}
-                {% if speaker %}
+                {% for file_id in site.data.speakers %}
+                    {% if file_id.id == speaker_id %}
+                        {% assign show_speakers = true %}
+                    {% endif %}
+                {% endfor %}
+            {% endfor %}
+
+            {% if show_speakers %}
                 <h2>Speaker(s)</h2>
                 <div class="row">
                     <div class="col-xs-12">
-                        <div class="col-sm-3 text-center">
-                            <a href="/speakers/#{{ speaker.id }}">
-                                <img class="clip-circle-speaker" src="{{ speaker.image_src }}" alt="{{ speaker.name }}">
-                                <span>{{ speaker.name }}</span>
-                            </a>
-                        </div>
+                        {% for speaker_id in page.speakers %}
+                            {% assign speaker = site.data.speakers | where: 'id', speaker_id | first %}
+                            {% if speaker %}
+                                <div class="col-sm-3 text-center">
+                                    <a href="/speakers/#{{ speaker.id }}">
+                                        <img class="clip-circle-speaker" src="{{ speaker.image_src }}" alt="{{ speaker.name }}">
+                                        <span>{{ speaker.name }}</span>
+                                    </a>
+                                </div>
+                            {% endif %}
+                        {% endfor %}
                     </div>
                 </div>
-                {% endif %}
-            {% endfor %}
+            {% endif %}
 
             {% if page.type == 'workshop' %}
             <div class="col-xs-12 col-sm-8 col-md-9">


### PR DESCRIPTION
I think I've fixed this so the speakers section only appears if the speaker id is found in the speakers.yml file. To test, add the following to one of the workshops in `_posts`:

```
speakers:
  - ophelia-the-omnipresent
  - melancholy-jaques
```