### PR TITLE
add conf talk posts, ref #127

### DIFF
--- a/_posts/2019-02-20-Aggregation-Without-Aggravation-auditing-metadata-at-scale.md
+++ b/_posts/2019-02-20-Aggregation-Without-Aggravation-auditing-metadata-at-scale.md
@@ -1,0 +1,19 @@
+---
+layout: presentation
+day: 2
+group: 
+spot: 33
+length: 20
+type: talk
+categories: talks
+time: 9:15
+startTime: 1550758500
+speakers-text: Teresa Hebron, , 
+speakers:
+- teresa-hebron
+- 
+- 
+slides: 
+title: Aggregation Without Aggravation&#58; auditing metadata at scale
+---
+As one of the Digital Public Library of America (DPLA)’s largest service hubs, Mountain West Digital Library aggregates metadata from over 70 institutions in the US Intermountain West. How can we efficiently and comprehensively audit thousands of metadata records for digitized special collections? We meet this challenge through the adoption of a tool coded by a fellow DPLA hub, North Carolina Digital Heritage Center, that uses XSL to test OAI-PMH feeds against our local metadata application profile. Building on MWDL’s original 2015 adaptation, the past year brought further updates to the tool that broadened its capabilities to support auditing for a diverse range of repositories, including CONTENTdm, Islandora, Samvera, and Solphal. This talk will discuss the project, technical challenges, pros and cons, and future directions.

--- a/_posts/2019-02-20-Aggregation-Without-Aggravation-auditing-metadata-at-scale.md
+++ b/_posts/2019-02-20-Aggregation-Without-Aggravation-auditing-metadata-at-scale.md
@@ -1,19 +1,19 @@
 ---
 layout: presentation
 day: 2
-group: 
+group:
 spot: 33
 length: 20
 type: talk
 categories: talks
 time: 9:15
 startTime: 1550758500
-speakers-text: Teresa Hebron, , 
+speakers-text: Teresa Hebron
 speakers:
 - teresa-hebron
-- 
-- 
-slides: 
+-
+-
+slides:
 title: Aggregation Without Aggravation&#58; auditing metadata at scale
 ---
 As one of the Digital Public Library of America (DPLA)’s largest service hubs, Mountain West Digital Library aggregates metadata from over 70 institutions in the US Intermountain West. How can we efficiently and comprehensively audit thousands of metadata records for digitized special collections? We meet this challenge through the adoption of a tool coded by a fellow DPLA hub, North Carolina Digital Heritage Center, that uses XSL to test OAI-PMH feeds against our local metadata application profile. Building on MWDL’s original 2015 adaptation, the past year brought further updates to the tool that broadened its capabilities to support auditing for a diverse range of repositories, including CONTENTdm, Islandora, Samvera, and Solphal. This talk will discuss the project, technical challenges, pros and cons, and future directions.

--- a/_posts/2019-02-20-Algorithm-Bias-Study.md
+++ b/_posts/2019-02-20-Algorithm-Bias-Study.md
@@ -1,0 +1,19 @@
+---
+layout: presentation
+day: 2
+group: 
+spot: 45
+length: 20
+type: talk
+categories: talks
+time: 13:35
+startTime: 1550774100
+speakers-text: Sheree Fu, Shalini Ramachandran, Steven Cutchin
+speakers:
+- sheree-fu
+- shalini-ramachandran
+- steven-cutchin
+slides: 
+title: Algorithm Bias Study
+---
+Recent discourse in information literacy has raised questions about bias in the Google search algorithm.  In our study, we consider whether pedagogy that raises awareness about how databases are designed by humans with pre-existing biases should be an important aspect of how librarians teach information literacy. As a first step in this process of developing information literacy modules for students about algorithmic bias, we surveyed computer science and engineering student population for their current perceptions about search engine and “big-data” algorithms. We will introduce the topic with a short summary of the book Algorithms of Oppression (2018) by Safiya Noble, present our preliminary findings and lessons learned, and conclude with proposed pathways for future research.

--- a/_posts/2019-02-20-Automating-link-management-When-institutional-infrastructure-works-against-you.md
+++ b/_posts/2019-02-20-Automating-link-management-When-institutional-infrastructure-works-against-you.md
@@ -1,0 +1,23 @@
+---
+layout: presentation
+day: 2
+group: 
+spot: 52
+length: 20
+type: talk
+categories: talks
+time: 16:20
+startTime: 1550784000
+speakers-text: Clara Turp, , 
+speakers:
+- clara-turp
+- 
+- 
+slides: 
+title: Automating link management&#58; When institutional infrastructure works against you
+---
+Managing resource links in academic libraries is increasingly challenging, especially in an e-preferred environment, as it involves keeping millions of links up to date at any given time. This presentation outlines a project undertaken in 2018 to solve this problem and the challenges encountered along the way. 
+
+I will begin by stepping through a solution that automatically manages open access links in OCLC’s WorldShare system. This approach uses OCLC’s Knowledge Base API to review the URL contained in particular collections’ KBART and sends monthly reports containing broken and redirecting links. 
+
+I will then discuss the challenges encountered regarding institutional infrastructure as well as strategies that facilitated the process of rewriting code for older versions while managing different python libraries. Choosing to use a university server seems like a straightforward decision due to various benefits, including complete automation and improved long-term code management. However, this is not so simple in a world where writing code in Python 3 (or even Python 2.7) is a radical departure from the status quo.

--- a/_posts/2019-02-20-Automating-link-management-When-institutional-infrastructure-works-against-you.md
+++ b/_posts/2019-02-20-Automating-link-management-When-institutional-infrastructure-works-against-you.md
@@ -8,7 +8,7 @@ type: talk
 categories: talks
 time: 16:20
 startTime: 1550784000
-speakers-text: Clara Turp, , 
+speakers-text: Clara Turp 
 speakers:
 - clara-turp
 - 

--- a/_posts/2019-02-20-Blockchain-for-Libraries-is-Snake-Oil.md
+++ b/_posts/2019-02-20-Blockchain-for-Libraries-is-Snake-Oil.md
@@ -8,7 +8,7 @@ type: talk
 categories: talks
 time: 14:25
 startTime: 1550690700
-speakers-text: Eric Hellman, ,
+speakers-text: Eric Hellman
 speakers:
 - eric-hellman
 -

--- a/_posts/2019-02-20-Blockchain-for-Libraries-is-Snake-Oil.md
+++ b/_posts/2019-02-20-Blockchain-for-Libraries-is-Snake-Oil.md
@@ -1,0 +1,23 @@
+---
+layout: presentation
+day: 1
+group:
+spot: 21
+length: 20
+type: talk
+categories: talks
+time: 14:25
+startTime: 1550690700
+speakers-text: Eric Hellman, ,
+speakers:
+- eric-hellman
+-
+-
+slides:
+title: "\"Blockchain for Libraries\" is Snake Oil"
+---
+Blockchain technology has proven to be an plausible, perhaps miraculous, underpinning for the sale, transfer and tracking of large integers. Libraries need to become adept in blockchain technology to the extent that they want to license, track and lend large integers. In other words, not ever.
+
+"Blockchain" is being used today to convey a magical aura to technical and commercial schemes with little justification for using blockchain. In every proposal for use of blockchain in libraries (not involving traffic in large integers) that I've examined, there has been no good reason, other than marketing, to invoke blockchain. Blockchain makes problems harder, vastly more expensive to solve, and completely resistant to scaling, and frequently inimical to library values of privacy and equity.
+
+Ironically, there are a number of technologies that have underpinnings common to blockchain that are ripe for more extensive exploitation in libraries. Git, peer-to-peer, cryptographic hashes, and public key signatures should all be in our tool chests. Let's resolve to use the blockchain bubble to advance our understanding and use of these underpinning technologies and steer clear of the inevitable blockchain bust.

--- a/_posts/2019-02-20-Building-A-Better-Database-List-with-APIs.md
+++ b/_posts/2019-02-20-Building-A-Better-Database-List-with-APIs.md
@@ -1,0 +1,20 @@
+---
+layout: presentation
+day: 1
+group: 
+spot: 8
+length: 20
+type: talk
+categories: talks
+time: 10:30
+startTime: 1550676600
+speakers-text: Veronica Ramshaw, , 
+speakers:
+- veronica-ramshaw
+- 
+- 
+slides: 
+title: Building A Better Database List with APIs
+---
+With a combination of automation and human attention, we were able to build a better Database A-Z List for our users and streamline our workflow by feeding LibGuides the data from our ILS's available APIs. 
+In this talk, I will cover how we achieved our goals and the lessons we learned through the process.

--- a/_posts/2019-02-20-Building-A-Better-Database-List-with-APIs.md
+++ b/_posts/2019-02-20-Building-A-Better-Database-List-with-APIs.md
@@ -8,7 +8,7 @@ type: talk
 categories: talks
 time: 10:30
 startTime: 1550676600
-speakers-text: Veronica Ramshaw, , 
+speakers-text: Veronica Ramshaw 
 speakers:
 - veronica-ramshaw
 - 

--- a/_posts/2019-02-20-Building-REST-APIbacked-Single-Page-Applications-SPAs-with-Vuejs.md
+++ b/_posts/2019-02-20-Building-REST-APIbacked-Single-Page-Applications-SPAs-with-Vuejs.md
@@ -1,0 +1,21 @@
+---
+layout: presentation
+day: 1
+group: 
+spot: 18
+length: 15
+type: talk
+categories: talks
+time: 13:45
+startTime: 1550688300
+speakers-text: Tim Walsh, , 
+speakers:
+- tim-walsh
+- 
+- 
+slides: 
+title: Building REST API-backed Single Page Applications (SPAs) with Vue.js
+---
+Vue.js is a progressive JavaScript framework that is rapidly becoming a popular alternative to the likes to React and Angular for front-end web development, with adoption by companies including Adobe, GitLab, Facebook, and Alibaba. As a progressive framework, Vue.js does not need to be implemented as an entire framework, and can also function as a modern ES6-handling jQuery replacement for applications where only a few lines of JavaScript are needed. 
+
+This talk will give a brief introduction to Vue.js and some of its tooling, demonstrate how Vue.js can be used to quickly build reactive Single Page Applications (SPAs) on top of existing databases and REST API services, and give some pointers on how to architect Vue.js applications that are expected to scale. As a powerful and flexible framework that can be used for fast prototyping and building production applications alike, Vue.js is a great tool for all library developers to have in their toolbox.

--- a/_posts/2019-02-20-Building-REST-APIbacked-Single-Page-Applications-SPAs-with-Vuejs.md
+++ b/_posts/2019-02-20-Building-REST-APIbacked-Single-Page-Applications-SPAs-with-Vuejs.md
@@ -8,7 +8,7 @@ type: talk
 categories: talks
 time: 13:45
 startTime: 1550688300
-speakers-text: Tim Walsh, , 
+speakers-text: Tim Walsh 
 speakers:
 - tim-walsh
 - 

--- a/_posts/2019-02-20-Code-It-Yourself-Teaching-Collections-Staff-to-Script.md
+++ b/_posts/2019-02-20-Code-It-Yourself-Teaching-Collections-Staff-to-Script.md
@@ -1,19 +1,19 @@
 ---
 layout: presentation
 day: 3
-group: 
+group:
 spot: 67
 length: 15
 type: talk
 categories: talks
 time: 12:00
 startTime: 1550854800
-speakers-text: Shawn Kiewel, Adriane Hanson, 
+speakers-text: Shawn Kiewel, Adriane Hanson
 speakers:
 - shawn-kiewel
 - adriane-hanson
-- 
-slides: 
+-
+slides:
 title: Code It Yourself! Teaching Collections Staff to Script
 ---
 We will share the University of Georgia Libraries' method for training collections staff to script using Python through a combination of a peer learning group and expert training from our Libraries' developer. The peer learning group (Lib Learn Tech) provides a support group for staff to work through online training together to learn Python basics. Our developer's workshops bridge the gap between learning about Python and being able to solve real-world problems using scripts such as renaming files, organizing files, and automatically running reports. These workshops emphasize how to think like and problem solve like a programmer so staff will be able to tackle additional problems on their own. Our goal is to cultivate an empowered staff who can script routine tasks, freeing up their (and our developer's) time for more complex pursuits.

--- a/_posts/2019-02-20-Code-It-Yourself-Teaching-Collections-Staff-to-Script.md
+++ b/_posts/2019-02-20-Code-It-Yourself-Teaching-Collections-Staff-to-Script.md
@@ -1,0 +1,19 @@
+---
+layout: presentation
+day: 3
+group: 
+spot: 67
+length: 15
+type: talk
+categories: talks
+time: 12:00
+startTime: 1550854800
+speakers-text: Shawn Kiewel, Adriane Hanson, 
+speakers:
+- shawn-kiewel
+- adriane-hanson
+- 
+slides: 
+title: Code It Yourself! Teaching Collections Staff to Script
+---
+We will share the University of Georgia Libraries' method for training collections staff to script using Python through a combination of a peer learning group and expert training from our Libraries' developer. The peer learning group (Lib Learn Tech) provides a support group for staff to work through online training together to learn Python basics. Our developer's workshops bridge the gap between learning about Python and being able to solve real-world problems using scripts such as renaming files, organizing files, and automatically running reports. These workshops emphasize how to think like and problem solve like a programmer so staff will be able to tackle additional problems on their own. Our goal is to cultivate an empowered staff who can script routine tasks, freeing up their (and our developer's) time for more complex pursuits.

--- a/_posts/2019-02-20-Consortial-discovery-and-resource-sharing-making-it-happen-with-mostly-standard-tools.md
+++ b/_posts/2019-02-20-Consortial-discovery-and-resource-sharing-making-it-happen-with-mostly-standard-tools.md
@@ -1,0 +1,19 @@
+---
+layout: presentation
+day: 1
+group: 
+spot: 20
+length: 10
+type: talk
+categories: talks
+time: 14:15
+startTime: 1550690100
+speakers-text: Emily Lynema, , 
+speakers:
+- emily-lynema
+- 
+- 
+slides: 
+title: Consortial discovery and resource sharing&#58; making it happen with (mostly) standard tools
+---
+With decreasing buying power in collections budgets and increasing emphasis on collaborative collection building across local and regional consortia, institutions may be looking for easier ways to expose and deliver these shared resources. The Triangle Research Libraries Network members (Duke, NCCU, NCSU, and UNC-CH libraries) have been building shared collections for decades and running a shared index for over 10 years. With the TRLN Discovery project, our consortium is migrating away from a customized vendor solution and leveraging common, open source tools (Solr, Blacklight) and shared infrastructure (AWS) to build a new discovery and delivery environment. This talk will broadly outline how these tools are being used and highlight a few interesting components that have been added to support consortial discovery. It will also cover how we have organized our development and governance processes on a consortial project with limited central resources and how we are approaching exposing the shared collection to institutional users in the interface. This talk is intended to expose alternatives to buying off-the-shelf products to support consortial discovery for other institutions interested in similar outcomes.

--- a/_posts/2019-02-20-Consortial-discovery-and-resource-sharing-making-it-happen-with-mostly-standard-tools.md
+++ b/_posts/2019-02-20-Consortial-discovery-and-resource-sharing-making-it-happen-with-mostly-standard-tools.md
@@ -8,7 +8,7 @@ type: talk
 categories: talks
 time: 14:15
 startTime: 1550690100
-speakers-text: Emily Lynema, , 
+speakers-text: Emily Lynema 
 speakers:
 - emily-lynema
 - 

--- a/_posts/2019-02-20-Enrich-Library-Collection-Analysis-using-Python.md
+++ b/_posts/2019-02-20-Enrich-Library-Collection-Analysis-using-Python.md
@@ -8,7 +8,7 @@ type: talk
 categories: talks
 time: 11:35
 startTime: 1550680500
-speakers-text: Pujit Koirala, , 
+speakers-text: Pujit Koirala 
 speakers:
 - pujit-koirala
 - 

--- a/_posts/2019-02-20-Enrich-Library-Collection-Analysis-using-Python.md
+++ b/_posts/2019-02-20-Enrich-Library-Collection-Analysis-using-Python.md
@@ -1,0 +1,19 @@
+---
+layout: presentation
+day: 1
+group: 
+spot: 12
+length: 15
+type: talk
+categories: talks
+time: 11:35
+startTime: 1550680500
+speakers-text: Pujit Koirala, , 
+speakers:
+- pujit-koirala
+- 
+- 
+slides: 
+title: Enrich Library Collection Analysis using Python
+---
+At our library, we have initiated a new project to harvest data from the CrossRef API using Python in order to understand faculty publication and citation preferences. I’ll present how we can query data based on author, DOI, or title. I’ll describe how I pull and parse the JSON data using Python. Parsing steps include data validation, cleaning, etc. Finally, I’ll describe how I export the data to MySQL for additional processing to integrate with subject-based collection analysis reports. 

--- a/_posts/2019-02-20-Ethics-for-information-professionals.md
+++ b/_posts/2019-02-20-Ethics-for-information-professionals.md
@@ -1,0 +1,24 @@
+---
+layout: presentation
+day: 1
+group: 
+spot: 19
+length: 15
+type: talk
+categories: talks
+time: 14:00
+startTime: 1550689200
+speakers-text: Sarah Rice, Bernadette Irizarry, 
+speakers:
+- sarah-rice
+- bernadette-irizarry
+- 
+slides: 
+title: Ethics for information professionals
+---
+"People who organize information for discovery and use not only make information accessible but also provide the lens through which others experience it. Designing information spaces involves making and imposing value choices, which positions us firmly in the realm of ethics. This topic is especially relevant as we hear more about “fake news,” “biased algorithms,” and unethical uses of personal data. 
+
+Individually, we have considered ethics at the micro level, for instance by finding ways to do good in specific projects or situations. But to what extent have we thought about ethics in the context of our overall profession? When we design do we, as practitioners, surrender our moral authority to someone else? Or do we follow a professional code?
+
+This talk provides key questions and guidelines for how to discuss a code of ethics that can be applied widely within information professions, including contexts and formats that may not have been considered before. 
+"

--- a/_posts/2019-02-20-Ethics-for-information-professionals.md
+++ b/_posts/2019-02-20-Ethics-for-information-professionals.md
@@ -1,24 +1,24 @@
 ---
 layout: presentation
 day: 1
-group: 
+group:
 spot: 19
 length: 15
 type: talk
 categories: talks
 time: 14:00
 startTime: 1550689200
-speakers-text: Sarah Rice, Bernadette Irizarry, 
+speakers-text: Sarah Rice, Bernadette Irizarry
 speakers:
 - sarah-rice
 - bernadette-irizarry
-- 
-slides: 
+-
+slides:
 title: Ethics for information professionals
 ---
-"People who organize information for discovery and use not only make information accessible but also provide the lens through which others experience it. Designing information spaces involves making and imposing value choices, which positions us firmly in the realm of ethics. This topic is especially relevant as we hear more about “fake news,” “biased algorithms,” and unethical uses of personal data. 
+"People who organize information for discovery and use not only make information accessible but also provide the lens through which others experience it. Designing information spaces involves making and imposing value choices, which positions us firmly in the realm of ethics. This topic is especially relevant as we hear more about “fake news,” “biased algorithms,” and unethical uses of personal data.
 
 Individually, we have considered ethics at the micro level, for instance by finding ways to do good in specific projects or situations. But to what extent have we thought about ethics in the context of our overall profession? When we design do we, as practitioners, surrender our moral authority to someone else? Or do we follow a professional code?
 
-This talk provides key questions and guidelines for how to discuss a code of ethics that can be applied widely within information professions, including contexts and formats that may not have been considered before. 
+This talk provides key questions and guidelines for how to discuss a code of ethics that can be applied widely within information professions, including contexts and formats that may not have been considered before.
 "

--- a/_posts/2019-02-20-GDPR-for-American-Public-Libraries.md
+++ b/_posts/2019-02-20-GDPR-for-American-Public-Libraries.md
@@ -8,7 +8,7 @@ type: talk
 categories: talks
 time: 9:55
 startTime: 1550760900
-speakers-text: Nathan Wittmaier, , 
+speakers-text: Nathan Wittmaier 
 speakers:
 - nathan-wittmaier
 - 

--- a/_posts/2019-02-20-GDPR-for-American-Public-Libraries.md
+++ b/_posts/2019-02-20-GDPR-for-American-Public-Libraries.md
@@ -1,0 +1,19 @@
+---
+layout: presentation
+day: 2
+group: 
+spot: 35
+length: 15
+type: talk
+categories: talks
+time: 9:55
+startTime: 1550760900
+speakers-text: Nathan Wittmaier, , 
+speakers:
+- nathan-wittmaier
+- 
+- 
+slides: 
+title: GDPR for American Public Libraries
+---
+The General Data Protection Regulation of the European Union came into full effect May 2018. The most visible impact of GDPR has been a cascade of cookie approvals and subscription confirmations to conform with the law. But what does a regulation in the EU mean for American public libraries? How does GDPR differ from U.S. laws, and how does it embody some of the best aspirations of libraries? This presentation offers a summary of important take-aways from GDPR for U.S. public library.

--- a/_posts/2019-02-20-Get-To-Know-WCAG-21.md
+++ b/_posts/2019-02-20-Get-To-Know-WCAG-21.md
@@ -1,0 +1,19 @@
+---
+layout: presentation
+day: 2
+group: 
+spot: 36
+length: 20
+type: talk
+categories: talks
+time: 10:10
+startTime: 1550761800
+speakers-text: Carli Spina, , 
+speakers:
+- carli-spina
+- 
+- 
+slides: 
+title: Get To Know WCAG 2.1
+---
+In the summer of 2018, W3C published a new version of Web Content Accessibility Guidelines (WCAG). WCAG 2.1 fills in gaps that were identified in WCAG 2.0 to improve accessibility across devices and for users with additional types of needs, particularly those with low vision or cognitive disabilities. This session will explain what developers and technologists need to know about these guidelines and how (and when) the guidelines will impact current practices. After this session, participants will have the information they need to decide whether and how to change the current accessibility policies and practices at their institution.

--- a/_posts/2019-02-20-Get-To-Know-WCAG-21.md
+++ b/_posts/2019-02-20-Get-To-Know-WCAG-21.md
@@ -8,7 +8,7 @@ type: talk
 categories: talks
 time: 10:10
 startTime: 1550761800
-speakers-text: Carli Spina, , 
+speakers-text: Carli Spina 
 speakers:
 - carli-spina
 - 

--- a/_posts/2019-02-20-Looking-for-Some-Hot-Stuff-Collaborating-on-the-Disco-Index-Project.md
+++ b/_posts/2019-02-20-Looking-for-Some-Hot-Stuff-Collaborating-on-the-Disco-Index-Project.md
@@ -1,0 +1,19 @@
+---
+layout: presentation
+day: 1
+group: 
+spot: 9
+length: 15
+type: talk
+categories: talks
+time: 10:50
+startTime: 1550677800
+speakers-text: Rhonda Kauffman, Helen Bailey, 
+speakers:
+- rhonda-kauffman
+- helen-bailey
+- 
+slides: 
+title: Looking for Some Hot Stuff&#58; Collaborating on the Disco Index Project
+---
+The MIT Libraries has recently experimented with creating our own Discovery Index, an indexing platform that will be used to populate searches and discovery from multiple sources across the Libraries via a public API. The “Disco Index” will allow us to rely less on vended sources while maintaining more control over our privacy and metadata. During this foundational exploration into creating the Disco Index, engineers teamed up with catalogers to analyze and map data elements from our library catalog. In this presentation we will discuss the project, plus how we worked together to demystify engineering and MARC, and learned a lot about each other’s work.

--- a/_posts/2019-02-20-Looking-for-Some-Hot-Stuff-Collaborating-on-the-Disco-Index-Project.md
+++ b/_posts/2019-02-20-Looking-for-Some-Hot-Stuff-Collaborating-on-the-Disco-Index-Project.md
@@ -1,19 +1,19 @@
 ---
 layout: presentation
 day: 1
-group: 
+group:
 spot: 9
 length: 15
 type: talk
 categories: talks
 time: 10:50
 startTime: 1550677800
-speakers-text: Rhonda Kauffman, Helen Bailey, 
+speakers-text: Rhonda Kauffman, Helen Bailey
 speakers:
 - rhonda-kauffman
 - helen-bailey
-- 
-slides: 
+-
+slides:
 title: Looking for Some Hot Stuff&#58; Collaborating on the Disco Index Project
 ---
 The MIT Libraries has recently experimented with creating our own Discovery Index, an indexing platform that will be used to populate searches and discovery from multiple sources across the Libraries via a public API. The “Disco Index” will allow us to rely less on vended sources while maintaining more control over our privacy and metadata. During this foundational exploration into creating the Disco Index, engineers teamed up with catalogers to analyze and map data elements from our library catalog. In this presentation we will discuss the project, plus how we worked together to demystify engineering and MARC, and learned a lot about each other’s work.

--- a/_posts/2019-02-20-Machine-Learning-and-Metadata-with-the-Charles-Teenie-Harris-Archive.md
+++ b/_posts/2019-02-20-Machine-Learning-and-Metadata-with-the-Charles-Teenie-Harris-Archive.md
@@ -8,7 +8,7 @@ type: talk
 categories: talks
 time: 11:20
 startTime: 1550679600
-speakers-text: Dominique Luster, , 
+speakers-text: Dominique Luster 
 speakers:
 - dominique-luster
 - 

--- a/_posts/2019-02-20-Machine-Learning-and-Metadata-with-the-Charles-Teenie-Harris-Archive.md
+++ b/_posts/2019-02-20-Machine-Learning-and-Metadata-with-the-Charles-Teenie-Harris-Archive.md
@@ -1,0 +1,19 @@
+---
+layout: presentation
+day: 1
+group: 
+spot: 11
+length: 15
+type: talk
+categories: talks
+time: 11:20
+startTime: 1550679600
+speakers-text: Dominique Luster, , 
+speakers:
+- dominique-luster
+- 
+- 
+slides: 
+title: Machine Learning and Metadata with the Charles Teenie Harris Archive
+---
+In July 2018, the project team (co-led by an archivist and a creative technologist) conducted a one-week of intensive, dedication to scripting and testing experimental code to document the limitations, capabilities, and costs of machine learning, text parsing, computer vision, and crowdsourcing technologies on making a meaningful contribution to archival metadata. This project is specifically designed to evaluate the viability of using technology to solve the problem of “dirty” data in the Charles Teenie Harris item-level catalog records. Charles “Teenie” Harris (1908-1998) was a photographer for The Pittsburgh Courier, one of the most influential black newspapers of the 20th century. In career spanning more than four decades, Harris captured the events and everyday experience of African American life in Pittsburgh in a collection of almost 80,000 images. This presentation will present the successes, challenges, and future opportunities (both archival and administrative) of this work, and how automation of metadata creation and cleaning can be applied to photography-based collections. 

--- a/_posts/2019-02-20-Machine-Learning-based-metadata-generation-for-library-archives.md
+++ b/_posts/2019-02-20-Machine-Learning-based-metadata-generation-for-library-archives.md
@@ -1,0 +1,19 @@
+---
+layout: presentation
+day: 2
+group: 
+spot: 40
+length: 20
+type: talk
+categories: talks
+time: 11:35
+startTime: 1550766900
+speakers-text: Dhanushka Samarakoon, Harish Maringanti, 
+speakers:
+- dhanushka-samarakoon
+- harish-maringanti
+- 
+slides: 
+title: Machine Learning based metadata generation for library archives
+---
+As libraries and cultural heritage organizations continue to acquire and digitize cultural and historical treasures, in the hopes of making them available to the general public, it is important to create quality descriptive metadata to increase the visibility of content. Creating quality metadata is a time-consuming process, and not all organizations may have enough metadata experts to describe the content quickly & accurately. We received funding from LYRASIS Catalyst grant to explore opportunities in using Machine Learning technology to simplify descriptive metadata generation for historical images. We will share updates on our work so far with a particular focus on the tools, techniques, and the outcomes of the project.

--- a/_posts/2019-02-20-Machine-Learning-based-metadata-generation-for-library-archives.md
+++ b/_posts/2019-02-20-Machine-Learning-based-metadata-generation-for-library-archives.md
@@ -1,19 +1,19 @@
 ---
 layout: presentation
 day: 2
-group: 
+group:
 spot: 40
 length: 20
 type: talk
 categories: talks
 time: 11:35
 startTime: 1550766900
-speakers-text: Dhanushka Samarakoon, Harish Maringanti, 
+speakers-text: Dhanushka Samarakoon, Harish Maringanti
 speakers:
 - dhanushka-samarakoon
 - harish-maringanti
-- 
-slides: 
+-
+slides:
 title: Machine Learning based metadata generation for library archives
 ---
 As libraries and cultural heritage organizations continue to acquire and digitize cultural and historical treasures, in the hopes of making them available to the general public, it is important to create quality descriptive metadata to increase the visibility of content. Creating quality metadata is a time-consuming process, and not all organizations may have enough metadata experts to describe the content quickly & accurately. We received funding from LYRASIS Catalyst grant to explore opportunities in using Machine Learning technology to simplify descriptive metadata generation for historical images. We will share updates on our work so far with a particular focus on the tools, techniques, and the outcomes of the project.

--- a/_posts/2019-02-20-Natural-Language-Processing-for-Discovery-of-BornDigital-Records.md
+++ b/_posts/2019-02-20-Natural-Language-Processing-for-Discovery-of-BornDigital-Records.md
@@ -8,7 +8,7 @@ type: talk
 categories: talks
 time: 13:30
 startTime: 1550687400
-speakers-text: Emily Higgs, , 
+speakers-text: Emily Higgs 
 speakers:
 - emily-higgs
 - 

--- a/_posts/2019-02-20-Natural-Language-Processing-for-Discovery-of-BornDigital-Records.md
+++ b/_posts/2019-02-20-Natural-Language-Processing-for-Discovery-of-BornDigital-Records.md
@@ -1,0 +1,19 @@
+---
+layout: presentation
+day: 1
+group: 
+spot: 17
+length: 15
+type: talk
+categories: talks
+time: 13:30
+startTime: 1550687400
+speakers-text: Emily Higgs, , 
+speakers:
+- emily-higgs
+- 
+- 
+slides: 
+title: Natural Language Processing for Discovery of Born-Digital Records
+---
+How do we move from discussing new technologies to actually implementing them? This presentation will cover several applications of NLP (natural language processing) for improving discovery of born-digital records in special collections and archives, focusing on two NLP-centered projects at the North Carolina State University Special Collections Research Center. The first is the implementation of out-of-the-box software tools to enable browsing collections by named entities in the reading room. The second project is the integration of named entity recognition and topic modeling into born-digital processing workflows in order to improve and automate aggregate description of collections. The presentation evaluates the success of these projects and describes possibilities for the future extension of these tools vis-à-vis practical applications. This presentation is framed in terms of working solutions that add value to the researcher experience in the library, and works to fill the gap between theoretical discussion of these tools and realized application.

--- a/_posts/2019-02-20-Of-Ethics-Users-and-Data-Building-a-National-Conversation-for-Web-Privacy-and-Web-Analytics.md
+++ b/_posts/2019-02-20-Of-Ethics-Users-and-Data-Building-a-National-Conversation-for-Web-Privacy-and-Web-Analytics.md
@@ -1,23 +1,23 @@
 ---
 layout: presentation
 day: 1
-group: 
+group:
 spot: 13
 length: 20
 type: talk
 categories: talks
 time: 11:50
 startTime: 1550681400
-speakers-text: Scott W. H. Young, Jason A. Clark, 
+speakers-text: Scott W. H. Young, Jason A. Clark
 speakers:
 - scott-w-h-young
 - jason-a-clark
-- 
-slides: 
+-
+slides:
 title: Of Ethics, Users, and Data&#58; Building a National Conversation for Web Privacy and Web Analytics
 ---
-Privacy is still a thing today—despite the best efforts of our favorite commercial web giants and state governments to turn privacy fully into a thing of the past. In the face of overwhelming surveillance and tracking pressures, libraries continue fighting for privacy on behalf of ourselves and our communities. 
+Privacy is still a thing today—despite the best efforts of our favorite commercial web giants and state governments to turn privacy fully into a thing of the past. In the face of overwhelming surveillance and tracking pressures, libraries continue fighting for privacy on behalf of ourselves and our communities.
 
-To aid in this battle, we convened “A National Forum on Web Privacy and Web Analytics.” This IMLS-funded project brought together 40 librarians, technologists, and privacy researchers from across the US and Canada to critically address library values and practices related to third-party analytics. Libraries have historically offered safe spaces of intellectual freedom, but the widespread implementation of third-party analytics may conflict with our commitments to privacy. With these challenges in mind, our Forum essentially asked, “How can libraries implement privacy-focused, values-driven analytics practices?” 
+To aid in this battle, we convened “A National Forum on Web Privacy and Web Analytics.” This IMLS-funded project brought together 40 librarians, technologists, and privacy researchers from across the US and Canada to critically address library values and practices related to third-party analytics. Libraries have historically offered safe spaces of intellectual freedom, but the widespread implementation of third-party analytics may conflict with our commitments to privacy. With these challenges in mind, our Forum essentially asked, “How can libraries implement privacy-focused, values-driven analytics practices?”
 
 This presentation will provide an overview of our National Forum and its results, including discussion of key challenges, strengths, partners, and strategies for achieving privacy on web. We will also focus on generating dialogue within the Code4Lib community, especially regarding analytics needs, implementation approaches, and real-world challenges for achieving privacy.

--- a/_posts/2019-02-20-Of-Ethics-Users-and-Data-Building-a-National-Conversation-for-Web-Privacy-and-Web-Analytics.md
+++ b/_posts/2019-02-20-Of-Ethics-Users-and-Data-Building-a-National-Conversation-for-Web-Privacy-and-Web-Analytics.md
@@ -1,0 +1,23 @@
+---
+layout: presentation
+day: 1
+group: 
+spot: 13
+length: 20
+type: talk
+categories: talks
+time: 11:50
+startTime: 1550681400
+speakers-text: Scott W. H. Young, Jason A. Clark, 
+speakers:
+- scott-w-h-young
+- jason-a-clark
+- 
+slides: 
+title: Of Ethics, Users, and Data&#58; Building a National Conversation for Web Privacy and Web Analytics
+---
+Privacy is still a thing today—despite the best efforts of our favorite commercial web giants and state governments to turn privacy fully into a thing of the past. In the face of overwhelming surveillance and tracking pressures, libraries continue fighting for privacy on behalf of ourselves and our communities. 
+
+To aid in this battle, we convened “A National Forum on Web Privacy and Web Analytics.” This IMLS-funded project brought together 40 librarians, technologists, and privacy researchers from across the US and Canada to critically address library values and practices related to third-party analytics. Libraries have historically offered safe spaces of intellectual freedom, but the widespread implementation of third-party analytics may conflict with our commitments to privacy. With these challenges in mind, our Forum essentially asked, “How can libraries implement privacy-focused, values-driven analytics practices?” 
+
+This presentation will provide an overview of our National Forum and its results, including discussion of key challenges, strengths, partners, and strategies for achieving privacy on web. We will also focus on generating dialogue within the Code4Lib community, especially regarding analytics needs, implementation approaches, and real-world challenges for achieving privacy.

--- a/_posts/2019-02-20-Optimizing-Library-Web-Content-for-Voice-Search.md
+++ b/_posts/2019-02-20-Optimizing-Library-Web-Content-for-Voice-Search.md
@@ -8,7 +8,7 @@ type: talk
 categories: talks
 time: 11:40
 startTime: 1550853600
-speakers-text: Tammy Allgood Wolf, , 
+speakers-text: Tammy Allgood Wolf 
 speakers:
 - tammy-allgood-wolf
 - 

--- a/_posts/2019-02-20-Optimizing-Library-Web-Content-for-Voice-Search.md
+++ b/_posts/2019-02-20-Optimizing-Library-Web-Content-for-Voice-Search.md
@@ -1,0 +1,19 @@
+---
+layout: presentation
+day: 3
+group: 
+spot: 66
+length: 20
+type: talk
+categories: talks
+time: 11:40
+startTime: 1550853600
+speakers-text: Tammy Allgood Wolf, , 
+speakers:
+- tammy-allgood-wolf
+- 
+- 
+slides: 
+title: Optimizing Library Web Content for Voice Search
+---
+About 20% of Google searches are currently voice searches. By 2020, it is likely that 50% of all searches in the United States will be done by voice. How can libraries ensure that the content we provide is adapted and optimized for people searching from their mobile devices or voice-activated assistants like Alexa, Siri, Cortana, and Google Home? Voice search has significant ramifications for online strategy. How can we ensure that libraries aren't left behind when half the population is searching through a virtual assistant? From Alexa Skills to structured data, this session will provide tips, tools and best practices for optimizing library-specific content for voice search.

--- a/_posts/2019-02-20-Programmatic-approaches-to-bias-in-descriptive-metadata.md
+++ b/_posts/2019-02-20-Programmatic-approaches-to-bias-in-descriptive-metadata.md
@@ -1,0 +1,21 @@
+---
+layout: presentation
+day: 1
+group: 
+spot: 7
+length: 15
+type: talk
+categories: talks
+time: 10:15
+startTime: 1550675700
+speakers-text: Noah Geraci, , 
+speakers:
+- noah-geraci
+- 
+- 
+slides: 
+title: Programmatic approaches to bias in descriptive metadata
+---
+"Cleaning" descriptive metadata is a frequent task in digital library work, often enabled by scripting or OpenRefine. But what about when the issue at hand isn't an odd schema, trailing whitespace, or inconsistent capitalization; but pervasive racial or gender bias in the descriptive language? Currently, the work of seeking to remediate the latter tends to be highly manual and reliant on individual judgment and prioritization, despite their systemic nature.
+
+This talk will explore what using programming to identify and address such biases might look like, and argue that seriously considering such an approach is essential to equitably publishing digital collections on a large scale. I'll discuss precedents and challenges for such work, and share two small experiments to this end in Python: one aided by Wikidata to replace LCSH terms for indigenous people in the U.S. with more currently preferred terminology, and another using natural language processing to identify where women are named as Mrs. [Husband's First Name] [Husband's Last Name].

--- a/_posts/2019-02-20-Programmatic-approaches-to-bias-in-descriptive-metadata.md
+++ b/_posts/2019-02-20-Programmatic-approaches-to-bias-in-descriptive-metadata.md
@@ -8,7 +8,7 @@ type: talk
 categories: talks
 time: 10:15
 startTime: 1550675700
-speakers-text: Noah Geraci, , 
+speakers-text: Noah Geraci 
 speakers:
 - noah-geraci
 - 

--- a/_posts/2019-02-20-Project-ReShare-Development--Piloting-of-an-Open-Source-Resource-Sharing-Platform.md
+++ b/_posts/2019-02-20-Project-ReShare-Development--Piloting-of-an-Open-Source-Resource-Sharing-Platform.md
@@ -1,19 +1,19 @@
 ---
 layout: presentation
 day: 3
-group: 
+group:
 spot: 65
 length: 20
 type: talk
 categories: talks
 time: 11:20
 startTime: 1550852400
-speakers-text: Jill Morris, Sebastian Hammer, 
+speakers-text: Jill Morris, Sebastian Hammer
 speakers:
 - jill-morris
 - sebastian-hammer
-- 
-slides: 
+-
+slides:
 title: Project ReShare&#58; Development & Piloting of an Open Source Resource Sharing Platform
 ---
 Libraries desire a user-centered resource sharing state, where patrons have seamless and informed access to information in any library, in any format. ReShare, as an open source, community-owned resource sharing platform, will significantly expand libraries’ current resource sharing capabilities and capacity, putting the patron and learner at the center of our collective collections ecosystem, with technology and/or profit playing a secondary role in facilitating access, rather than defining it. Consortia in the U.S. and abroad represent thousands of individual libraries operating resource sharing within commercially imposed technology silos. ReShare will provide a platform that any library/consortium may use to expand sharing within and between networks, regardless of choice of integrated library or discovery system to build capacity, saving time and money, while simultaneously supporting teaching, learning, and research activities.

--- a/_posts/2019-02-20-Project-ReShare-Development--Piloting-of-an-Open-Source-Resource-Sharing-Platform.md
+++ b/_posts/2019-02-20-Project-ReShare-Development--Piloting-of-an-Open-Source-Resource-Sharing-Platform.md
@@ -1,0 +1,19 @@
+---
+layout: presentation
+day: 3
+group: 
+spot: 65
+length: 20
+type: talk
+categories: talks
+time: 11:20
+startTime: 1550852400
+speakers-text: Jill Morris, Sebastian Hammer, 
+speakers:
+- jill-morris
+- sebastian-hammer
+- 
+slides: 
+title: Project ReShare&#58; Development & Piloting of an Open Source Resource Sharing Platform
+---
+Libraries desire a user-centered resource sharing state, where patrons have seamless and informed access to information in any library, in any format. ReShare, as an open source, community-owned resource sharing platform, will significantly expand libraries’ current resource sharing capabilities and capacity, putting the patron and learner at the center of our collective collections ecosystem, with technology and/or profit playing a secondary role in facilitating access, rather than defining it. Consortia in the U.S. and abroad represent thousands of individual libraries operating resource sharing within commercially imposed technology silos. ReShare will provide a platform that any library/consortium may use to expand sharing within and between networks, regardless of choice of integrated library or discovery system to build capacity, saving time and money, while simultaneously supporting teaching, learning, and research activities.

--- a/_posts/2019-02-20-Providing-Computational-Access-to-Records-of-American-Capital-Punishment.md
+++ b/_posts/2019-02-20-Providing-Computational-Access-to-Records-of-American-Capital-Punishment.md
@@ -1,19 +1,17 @@
 ---
 layout: presentation
 day: 1
-group: 
+group:
 spot: 10
 length: 15
 type: talk
 categories: talks
 time: 11:05
 startTime: 1550678700
-speakers-text: Gregory Wiedeman, Second presenter depends on funding, 
+speakers-text: Gregory Wiedeman
 speakers:
 - gregory-wiedeman
-- second-presenter-depends-on-funding
-- 
-slides: 
+slides:
 title: Providing Computational Access to Records of American Capital Punishment
 ---
 This talk will overview a two-year project to digitize and expose data from the most complete collection on American executions using the open architectures of Hyrax and Arclight. We’ll show how connecting data to digital source material provides important context for executions with limited or conflicting documentation, and allows for significant additions to the known set of executions that alters the overall makeup of the collection. This talk will discuss the challenges of presenting this material transparently and empathetically, and show how Linked Data can actually work to undermine these goals. Finally, we’ll discuss how this project will support computational access to all archival materials at our repository, and overview the ongoing challenges we face implementing and maintaining complex tools at a mid-size institution.

--- a/_posts/2019-02-20-Providing-Computational-Access-to-Records-of-American-Capital-Punishment.md
+++ b/_posts/2019-02-20-Providing-Computational-Access-to-Records-of-American-Capital-Punishment.md
@@ -1,0 +1,19 @@
+---
+layout: presentation
+day: 1
+group: 
+spot: 10
+length: 15
+type: talk
+categories: talks
+time: 11:05
+startTime: 1550678700
+speakers-text: Gregory Wiedeman, Second presenter depends on funding, 
+speakers:
+- gregory-wiedeman
+- second-presenter-depends-on-funding
+- 
+slides: 
+title: Providing Computational Access to Records of American Capital Punishment
+---
+This talk will overview a two-year project to digitize and expose data from the most complete collection on American executions using the open architectures of Hyrax and Arclight. We’ll show how connecting data to digital source material provides important context for executions with limited or conflicting documentation, and allows for significant additions to the known set of executions that alters the overall makeup of the collection. This talk will discuss the challenges of presenting this material transparently and empathetically, and show how Linked Data can actually work to undermine these goals. Finally, we’ll discuss how this project will support computational access to all archival materials at our repository, and overview the ongoing challenges we face implementing and maintaining complex tools at a mid-size institution.

--- a/_posts/2019-02-20-Ringers-of-Jupyter-The-Jupyter-Notebook-As-Faux-Web-App.md
+++ b/_posts/2019-02-20-Ringers-of-Jupyter-The-Jupyter-Notebook-As-Faux-Web-App.md
@@ -8,7 +8,7 @@ type: talk
 categories: talks
 time: 13:55
 startTime: 1550775300
-speakers-text: Jeff Gerhard, , 
+speakers-text: Jeff Gerhard 
 speakers:
 - jeff-gerhard
 - 

--- a/_posts/2019-02-20-Ringers-of-Jupyter-The-Jupyter-Notebook-As-Faux-Web-App.md
+++ b/_posts/2019-02-20-Ringers-of-Jupyter-The-Jupyter-Notebook-As-Faux-Web-App.md
@@ -1,0 +1,21 @@
+---
+layout: presentation
+day: 2
+group: 
+spot: 46
+length: 20
+type: talk
+categories: talks
+time: 13:55
+startTime: 1550775300
+speakers-text: Jeff Gerhard, , 
+speakers:
+- jeff-gerhard
+- 
+- 
+slides: 
+title: Ringers of Jupyter&#58; The Jupyter Notebook As Faux Web App
+---
+In the dark basement of an academic library, a project manager ponders. The current dilemma, involving data entry, metadata manipulation, and file management, is a poser. It requires a hefty dose of automation, a smattering of written instruction, a handful of hyperlinks, and manual examination of image files. Oh, and also, the scale of the project would require multiple workers, including student employees. The librarian, an amateur programmer, sighs. A polished web app could surely do the job, but feels far out of reach. A tangle of batch scripts and Python code, which the perplexed manager could happily patch together, seems like it would too intimidating and complex for student workers to run. 
+
+But what about Jupyter Notebooks? Could they, by providing a familiar web browser interface, mask hacky Python code and fill in the gap between the frightening command line and a full-fledged application? Could the library deploy Jupyter Notebooks at (small) scale, as a user-friendly, in-browser method of running handcrafted code? And could your library do the same?

--- a/_posts/2019-02-20-Shear-forces-a-conceptual-model-for-understanding-and-coping-with-risk-change-and-technical-debt.md
+++ b/_posts/2019-02-20-Shear-forces-a-conceptual-model-for-understanding-and-coping-with-risk-change-and-technical-debt.md
@@ -8,7 +8,7 @@ type: talk
 categories: talks
 time: 16:00
 startTime: 1550782800
-speakers-text: Andreas Orphanides, , 
+speakers-text: Andreas Orphanides 
 speakers:
 - andreas-orphanides
 - 

--- a/_posts/2019-02-20-Shear-forces-a-conceptual-model-for-understanding-and-coping-with-risk-change-and-technical-debt.md
+++ b/_posts/2019-02-20-Shear-forces-a-conceptual-model-for-understanding-and-coping-with-risk-change-and-technical-debt.md
@@ -1,0 +1,23 @@
+---
+layout: presentation
+day: 2
+group: 
+spot: 51
+length: 20
+type: talk
+categories: talks
+time: 16:00
+startTime: 1550782800
+speakers-text: Andreas Orphanides, , 
+speakers:
+- andreas-orphanides
+- 
+- 
+slides: 
+title: Shear forces&#58; a conceptual model for understanding (and coping with) risk, change, and technical debt
+---
+A student searches in vain for a seat close enough to a power outlet to plug in her laptop. The IT department maintains a Windows XP server to support critical software for which there's no modern replacement. Your local fitness studio has a never-used, wall-mounted iPod dock set into the drywall.
+
+Our work processes naturally evolve, improve, and adapt to changing environments. Because of this, we often find ourselves in situations where the supporting components of the system struggle to keep up. This is because the various layers of a system evolve at different speeds: software can be purchased and deployed relatively quickly, but hardware is only refreshed every three years; furniture is easy to rearrange, but updating building infrastructure is costly and disruptive; complex workflows are built on legacy components that linger long after their normal service life. To borrow a concept from fluid dynamics, the result is a "shear force" where layers at different velocities interact. Too much shear leads to turbulence, which can actively disrupt the useful work of the system.
+
+Shear forces can't be completely avoided, and indeed attempts to proactively manage them sometimes lead to significant sunk costs. But considering change, risk, and technical debt in terms of shear can help us to make decisions in a more flexible and future-resistant way. In this presentation we'll look at examples of shear forces in both physical spaces and library systems, to better understand how we can observe, predict, and account for shear in our work. We'll explore how shear as a conceptual model can help us plan for changes not yet upon us, and consider how to make the liminal aspects of our systems, where the layers come into contact, more tolerant of shear forces, in order to ensure that the system remains performant even in times of change.

--- a/_posts/2019-02-20-The-Websites-that-Librarians-Love-but-are-they-ACCESSIBLE.md
+++ b/_posts/2019-02-20-The-Websites-that-Librarians-Love-but-are-they-ACCESSIBLE.md
@@ -8,7 +8,7 @@ type: talk
 categories: talks
 time: 11:00
 startTime: 1550851200
-speakers-text: Katherine Deibel, , 
+speakers-text: Katherine Deibel 
 speakers:
 - katherine-deibel
 - 

--- a/_posts/2019-02-20-The-Websites-that-Librarians-Love-but-are-they-ACCESSIBLE.md
+++ b/_posts/2019-02-20-The-Websites-that-Librarians-Love-but-are-they-ACCESSIBLE.md
@@ -1,0 +1,19 @@
+---
+layout: presentation
+day: 3
+group: 
+spot: 64
+length: 20
+type: talk
+categories: talks
+time: 11:00
+startTime: 1550851200
+speakers-text: Katherine Deibel, , 
+speakers:
+- katherine-deibel
+- 
+- 
+slides: 
+title: The Websites that Librarians Love... but are they ACCESSIBLE?!?
+---
+DuckDuckGo. LibGuides. Google Scholar. Libraries "love" these sites. Librarians recommend them. Our patrons sometimes use them. But is that a good thing? We have many metrics to evaluate how well a site performs. One of these (albeit often overlooked) is web accessibility. So how well do these sites fare when it comes to web accessibility. This talk will give an overview of each site's accessibility and highlight what is good and what is horrible. Simple accessibility tests and heuristics for anyone to use will be demonstrated. Learn which sites come out victorious and which ones fail horribly. Will your fave come out smelling like roses? 

--- a/_posts/2019-02-20-Using-MediaWiki--WikiBase-as-a-platform-for-library-linked-data-a-pilot-study.md
+++ b/_posts/2019-02-20-Using-MediaWiki--WikiBase-as-a-platform-for-library-linked-data-a-pilot-study.md
@@ -8,7 +8,7 @@ type: talk
 categories: talks
 time: 11:55
 startTime: 1550768100
-speakers-text: Jeff Mixter, , 
+speakers-text: Jeff Mixter 
 speakers:
 - jeff-mixter
 - 

--- a/_posts/2019-02-20-Using-MediaWiki--WikiBase-as-a-platform-for-library-linked-data-a-pilot-study.md
+++ b/_posts/2019-02-20-Using-MediaWiki--WikiBase-as-a-platform-for-library-linked-data-a-pilot-study.md
@@ -1,0 +1,19 @@
+---
+layout: presentation
+day: 2
+group: 
+spot: 41
+length: 20
+type: talk
+categories: talks
+time: 11:55
+startTime: 1550768100
+speakers-text: Jeff Mixter, , 
+speakers:
+- jeff-mixter
+- 
+- 
+slides: 
+title: Using MediaWiki + WikiBase as a platform for library linked data&#58; a pilot study
+---
+In this talk, we will provide a high-level overview of the MediaWiki and Wikibase platform, share the details of our recent 16 library pilot project, highlight the advantages and disadvantages of the platform, review our extensions, and share lessons learned and evaluations from the project participant libraries. Wikidata has evolved into a very important data source for those working with Linked Data, and the library/archive/museum communities’ interest in using Wikidata, both as a place to syndicate data as well as a source for data, has grown accordingly. The underlying technology platform for Wikidata is a MediaWiki extension called WikiBase, which enables the creation and storage of structured data in MediaWiki.  During the pilot, OCLC deployed MediaWiki and WikiBase as a linked data platform, evaluating its capabilities for describing, curating, and discovering entities and relationships relevant to the library/archive/museum domains. We started with existing entities mined from the OCLC WorldCat database, combined with corresponding Wikidata data, to seed the dataset and then worked with project participants from 16 OCLC member libraries to explore, modify, and enhance the data. In addition to using the built-in features of this platform, we developed two applications to assist with data exploration and import. 

--- a/_posts/2019-02-20-Webrecorder-Developing-an-OpenSource-HighFidelity-Web-Archiving-Toolset.md
+++ b/_posts/2019-02-20-Webrecorder-Developing-an-OpenSource-HighFidelity-Web-Archiving-Toolset.md
@@ -1,0 +1,19 @@
+---
+layout: presentation
+day: 2
+group: 
+spot: 34
+length: 20
+type: talk
+categories: talks
+time: 9:35
+startTime: 1550759700
+speakers-text: Ilya Kreymer, , 
+speakers:
+- ilya-kreymer
+- 
+- 
+slides: 
+title: Webrecorder&#58; Developing an Open-Source High-Fidelity Web Archiving Toolset
+---
+The talk will present the open source technology stack that powers Webrecorder and address some of the many challenges and possible solutions facing web archiving today. First, it will include a brief technical overview of high-fidelity web capture and replay, and general approaches to make high-fidelity web content accessible in the future will be presented. A practical guide to the open source tools developed as part of the Webrecorder toolset will also be included, aiming to help users and developers of all levels to improve their understanding, usage and creation of web archives to meet their personal and institutional needs. At the end, I hope to leave some time to answer any general questions about Webrecorder or web archiving technology in general.

--- a/_posts/2019-02-20-Webrecorder-Developing-an-OpenSource-HighFidelity-Web-Archiving-Toolset.md
+++ b/_posts/2019-02-20-Webrecorder-Developing-an-OpenSource-HighFidelity-Web-Archiving-Toolset.md
@@ -8,7 +8,7 @@ type: talk
 categories: talks
 time: 9:35
 startTime: 1550759700
-speakers-text: Ilya Kreymer, , 
+speakers-text: Ilya Kreymer 
 speakers:
 - ilya-kreymer
 - 

--- a/_posts/2019-02-20-Why-building-a-complete-index-of-open-access-to-research-articles-is-hard-and-how-you-can-help.md
+++ b/_posts/2019-02-20-Why-building-a-complete-index-of-open-access-to-research-articles-is-hard-and-how-you-can-help.md
@@ -1,0 +1,19 @@
+---
+layout: presentation
+day: 2
+group: 
+spot: 53
+length: 20
+type: talk
+categories: talks
+time: 16:40
+startTime: 1550785200
+speakers-text: Jason Priem, , 
+speakers:
+- jason-priem
+- 
+- 
+slides: 
+title: Why building a complete index of open access to research articles is hard and how you can help
+---
+Our nonprofit has gathered every open access scholarly article--over 20 million of them--into one free database. Come hear about the obstacles in assembling the index: confusing definitions!  poor metadata quality!  standards that weren't standard!  And more!  We'll detail the issues, how we've overcome them with a completely open-source solution, and how you can help :)

--- a/_posts/2019-02-20-Why-building-a-complete-index-of-open-access-to-research-articles-is-hard-and-how-you-can-help.md
+++ b/_posts/2019-02-20-Why-building-a-complete-index-of-open-access-to-research-articles-is-hard-and-how-you-can-help.md
@@ -8,7 +8,7 @@ type: talk
 categories: talks
 time: 16:40
 startTime: 1550785200
-speakers-text: Jason Priem, , 
+speakers-text: Jason Priem 
 speakers:
 - jason-priem
 - 


### PR DESCRIPTION
Still need to fill in group IDs for these, they will not work on the schedule until then. We won't know group IDs until schedule is done. Slides can be added later just before/during conference.

To test: load up /talks/ and make sure they all appear and correctly link to their speakers.