### PR TITLE
new Safiya Noble bio

### DIFF
--- a/_data/speakers.yml
+++ b/_data/speakers.yml
@@ -1,12 +1,3 @@
-- id: safiya-noble
-  name: Safiya Noble
-  last: Noble
-  title: Assistant Professor
-  institution: University of Southern California
-  image_src: /assets/img/speakers/noble_safiya.jpg
-  keynote: true
-  bio: "Dr. Safiya U. Noble is an assistant professor at the University of Southern California (USC) Annenberg School of Communication. She is the recipient of a Hellman Fellowship and the UCLA Early Career Award. Noble’s academic research focuses on the design of digital media platforms on the internet and their impact on society. Her work is both sociological and interdisciplinary, marking the ways that digital media impacts and intersects with issues of race, gender, culture, and technology design. Her critically-acclaimed monograph on racist and sexist algorithmic bias in commercial search engines is entitled <a href='https://nyupress.org/books/9781479837243/'>Algorithms of Oppression: How Search Engines Reinforce Racism</a> (NYU Press)."
-
 - id: tara-robertson
   name: Tara Robertson
   last: Robertson
@@ -15,6 +6,15 @@
   image_src: /assets/img/speakers/robertson_tara.jpg
   keynote: true
   bio: "Tara Robertson is an intersectional feminist who uses data and research to advocate for equality and inclusion. She has more than 10 years experience making open source and tech communities more diverse and welcoming. Her core values are social justice, collaboration and all things open–open source, open access and open education. Her curiosity and delight in connecting people come together in person and online, where she can often be found asking good questions. <a href=https://tararobertson.ca/about/>Read more on her personal website</a>."
+
+- id: safiya-noble
+  name: Safiya Noble
+  last: Noble
+  title: Assistant Professor
+  institution: University of Southern California
+  image_src: /assets/img/speakers/noble_safiya.jpg
+  keynote: true
+  bio: "Dr. Safiya Umoja Noble is an Associate Professor at UCLA in the Departments of Information Studies and African American Studies, and a visiting faculty member to the University of Southern California’s Annenberg School of Communication. Previously, she was an Assistant Professor in Department of Media and Cinema Studies and the Institute for Communications Research at the University of Illinois at Urbana-Champaign. She is the author of a best-selling, critically-acclaimed book on racist and sexist algorithmic bias in commercial search engines, entitled <a href='https://nyupress.org/books/9781479837243/'>Algorithms of Oppression: How Search Engines Reinforce Racism</a> (NYU Press). Safiya is the recipient of a Hellman Fellowship and the UCLA Early Career Award. Her academic research focuses on the design of digital media platforms on the internet and their impact on society. Her work is both sociological and interdisciplinary, marking the ways that digital media impacts and intersects with issues of race, gender, culture, and technology. She is regularly quoted for her expertise on issues of algorithmic discrimination and technology bias by national and international press including The Guardian, the BBC, CNN International, USA Today, Wired, Time, and The New York Times, to name a few."
 
 - id: carolyn-moritz
   name: Carolyn Moritz


### PR DESCRIPTION
also reorder the two keynotes to match the conference

I tried to do two paragraphs for Noble's bio (split is right after the hyperlinked book title) but couldn't find a way to given the site's setup. It looks awful if you wrap the paragraphs in `<p>` tags because they're already the children of a `<p>` tag and placing a `<br>` after the book title does nothing. I'm not too worried about it but if anyone else has an idea, take a shot.