### PR TITLE
prepare for stream, closed-captioning, show slides button

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -4,7 +4,6 @@
 year: 2019
 hashtag: 'c4l19'
 location: 'San José, California'
-captioning-url: ""
 hero-image-alt: "a collage of several San José landmarks"
 
 search: false
@@ -237,13 +236,17 @@ volunteer-onsite:
 ###########
 livestream:
   show: false
-  url: "https://www.youtube.com/playlist?list=PLw-ls5JXzeNZc3FZMem-uLCPgiTM9IzKg"
+  url: "https://www.youtube.com/code4lib"
 
 slides:
-  show: false
+  show: true
   url: "https://osf.io/view/c4l19/"
   contact: "Roy Tennant"
   email: "roytennant@gmail.com"
+
+closed-captioning:
+  url: ""
+  show: false
 
 ################
 # Scholarships

--- a/_includes/homepage/jumbotron.html
+++ b/_includes/homepage/jumbotron.html
@@ -19,8 +19,14 @@
                 <div id="conferenceActions">
                     <!-- Livestream -->
                     {% if site.data.conf.livestream.show %}
-                    <a class="btn btn-lg jumbotron-btn" href="{{ site.data.conf.livestream.url }}">Livestream Archive</a>
-                    <a class="btn btn-lg jumbotron-btn" href="{{ site.data.conf.captioning-url }}">Closed captioning</a>
+                        <a class="btn btn-lg jumbotron-btn" href="{{ site.data.conf.livestream.url }}">
+                            Livestream {% if site.data.conf.homepage-display = 'post' %} Archive{% endif %}
+                        </a>
+                    {% endif %}
+                    {% if site.data.conf.closed-captioning.show %}
+                        <a class="btn btn-lg jumbotron-btn" href="{{ site.data.conf.closed-captioning.url }}">
+                            Closed captioning
+                        </a>
                     {% endif %}
 
                     <!-- Register -->

--- a/general-info/accessibility.html
+++ b/general-info/accessibility.html
@@ -62,9 +62,9 @@ subnav:
 
             <h2>Live Captioning</h2>
             <p>During the general conference, Code4Lib {{site.data.conf.year}} will feature live captioning.
-            {% if site.data.conf.captioning-url != "" %}
+            {% if site.data.conf.closed-captioning.show %}
                Attendees, both local and remote, may view the text stream at:
-               <a href="{{site.data.conf.captioning-url}}">{{site.data.conf.captioning-url}}</a>.
+               <a href="{{site.data.conf.closed-captioning.url}}">{{site.data.conf.closed-captioning.url}}</a>.
             {% endif %}
             </p>
 

--- a/general-info/attend.html
+++ b/general-info/attend.html
@@ -115,9 +115,14 @@ active: Attend Code4Lib
                     <a href="{{ site.data.conf.social-links.irc}}">IRC</a>, and <a href="https://instagram.com/explore/tags/{{site.data.conf.hashtag}}/">Instagram</a>.
                 </p>
 
-                <!--
                 <h3>Live Transcription</h3>
-                <p>We are thrilled to be able to provide <a href="{{site.data.conf.captioning-url}}">live transcriptions of all the presentations</a>,
+                <p>
+                    We are thrilled to be able to provide
+                    {% if site.data.conf.closed-captioning.show %}
+                        <a href="{{site.data.conf.closed-captioning.url}}">
+                    {% endif %}
+                        live transcriptions of all the presentations
+                    {% if site.data.conf.closed-captioning.show %}</a>{% endif %},
                     thanks to Temple University Libraries.
                 </p>
 
@@ -128,7 +133,6 @@ active: Attend Code4Lib
                         </a>
                     </div>
                 </div>
-                -->
             </div>
         </div>
     </div>

--- a/general-info/venues/accommodations.html
+++ b/general-info/venues/accommodations.html
@@ -20,9 +20,9 @@
         <h3>Live Captioning</h3>
         <p>
             During the general conference, Code4Lib 2019 will feature live captioning.
-            {% if site.data.conf.captioning-url != '' %}
+            {% if site.data.conf.closed-captioning.show %}
                 Attendees, both local and remote, may view the text stream at:
-                <a href="{{ site.data.conf.captioning-url }}">{{ site.data.conf.captioning-url }}</a>.
+                <a href="{{ site.data.conf.closed-captioning.url }}">{{ site.data.conf.closed-captioning.url }}</a>.
             {% endif %}
         </p>
     </div>


### PR DESCRIPTION
This PR does a few things. Changes to

- home page
- gen info > accessibility
- gen info > attend
- gen info > venues > accommodations

it _does not_ display the livestream link just yet but does put it in place. We still don't know the closed captioning link (I'll add it ASAP) but this restructures how that is set up in conf.yml to resemble the livestream and slides repository. Slides repo is set to display.