### PR TITLE
dat

### DIFF
--- a/.well-known/dat
+++ b/.well-known/dat
@@ -1,0 +1,2 @@
+dat://c137a24af2a6dffc8975ba3ad17599c5d75a03a11c242b446b14cb53dfdfba36
+TTL=3600

--- a/README.md
+++ b/README.md
@@ -62,3 +62,24 @@ See a list of [open issues](https://github.com/code4lib/2019.code4lib.org/issues
 4. ```bundle exec jekyll serve```
 5. Check [http://localhost:4000](http://localhost:4000) that nothing is broken
 6. Merge that branch into master (easiest to manage on the GitHub site)
+
+## Dat
+
+As an experiment the site is also available via [Dat](https://datproject.org/) which you can view
+in the [Beaker Browser](https://beakerbrowser.com/) at dat://2019.code4lib.org.
+If you would like to clone the site you'll need to install Dat and then:
+
+    dat clone dat://2019.code4lib.org
+
+If you want to update the Dat site you'll need to import the secret key from a
+friend:
+
+    dat keys import < 2019.code4lib.org
+
+Then you'll need to:
+
+    rm -rf _site
+    dat clone dat://2019.code4lib.org _site
+    jekyll build
+    cd _site
+    dat sync

--- a/_config.yml
+++ b/_config.yml
@@ -6,3 +6,8 @@ future: true
 timezone: America/New_York
 sass:
   sass_dir: assets/_scss
+include:
+  - .well-known
+keep_files:
+  - .dat
+  - dat.json


### PR DESCRIPTION
This small commit adds some things to make the site available via Dat at
dat://2019.code4lib.org. If you want I can give someone the key to allow
them to update the site. Or I am happy to do it when there are changes.
I just thought it might be a fun experiment.

Note: the dat://2019.code4lib.org URL won't work until this commit is
merged. This is because it depends on 2019.code4lib.org/.well-known/dat
being published.

But in the meantime you should be able to clone it or view it in Beaker
at:

dat://c137a24af2a6dffc8975ba3ad17599c5d75a03a11c242b446b14cb53dfdfba36